### PR TITLE
Improvement and release version 1.0.4

### DIFF
--- a/MapComposer/pom.xml
+++ b/MapComposer/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.orbisgis</groupId>
     <artifactId>map-composer</artifactId>
     <name>Map Composer</name>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.0.4</version>
     <packaging>bundle</packaging>
     <description>OrbisGIS plugin for the composition of cartographic documents.</description>
     <parent>

--- a/MapComposer/pom.xml
+++ b/MapComposer/pom.xml
@@ -88,12 +88,6 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>org.orbisgis</groupId>
-            <artifactId>mapeditor</artifactId>
-            <version>5.1.0-SNAPSHOT</version>
-            <type>jar</type>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.10</version>
@@ -109,6 +103,26 @@
             <groupId>org.dockingframes</groupId>
             <artifactId>docking-frames-ext-toolbar-common</artifactId>
             <version>1.1.2-P5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.orbisgis</groupId>
+            <artifactId>orbisgis-sif</artifactId>
+            <version>5.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.orbisgis</groupId>
+            <artifactId>map-editor-api</artifactId>
+            <version>5.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.orbisgis</groupId>
+            <artifactId>wkgui-api</artifactId>
+            <version>5.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.orbisgis</groupId>
+            <artifactId>mainframe</artifactId>
+            <version>5.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <properties>

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/Activator.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/Activator.java
@@ -28,6 +28,8 @@ import org.orbisgis.corejdbc.DataManager;
 import org.orbisgis.mainframe.api.MainFrameAction;
 import org.orbisgis.mapcomposer.view.ui.MainWindow;
 import org.orbisgis.mapcomposer.view.utils.MapComposerIcon;
+import org.orbisgis.mapeditor.map.MapEditor;
+import org.orbisgis.mapeditorapi.MapEditorExtension;
 import org.orbisgis.sif.components.actions.DefaultAction;
 import org.orbisgis.wkguiapi.ViewWorkspace;
 import org.osgi.service.cm.Configuration;
@@ -64,6 +66,7 @@ public class Activator implements MainFrameAction {
 
     private DataManager dataManager;
     private ViewWorkspace viewWorkspace;
+    private MapEditorExtension mapEditorExtension;
 
     private Dictionary<String, Object> properties;
 
@@ -102,8 +105,13 @@ public class Activator implements MainFrameAction {
         this.viewWorkspace = viewWorkspace;
     }
 
+    @Reference
+    protected void setMapEditorExtension(MapEditorExtension mapEditorExtension){
+        this.mapEditorExtension = mapEditorExtension;
+    }
+
     protected void unsetDataManager(DataManager dataManager) {
-        this.mainWindow.setDataManager(null);
+        this.dataManager = null;
     }
 
     protected void unsetViewWorkspace(ViewWorkspace viewWorkspace) {
@@ -112,6 +120,10 @@ public class Activator implements MainFrameAction {
 
     protected void unsetConfigurationAdmin(ConfigurationAdmin configurationAdmin){
         this.mainWindow.setConfigurationAdmin(null);
+    }
+
+    protected void unsetMapEditorExtension(MapEditorExtension mapEditorExtension){
+        this.mapEditorExtension = null;
     }
 
     @Deactivate
@@ -144,6 +156,7 @@ public class Activator implements MainFrameAction {
             mainWindow.setDataManager(this.dataManager);
             mainWindow.setViewWorkspace(this.viewWorkspace);
             mainWindow.setConfigurationAdmin(this.configurationAdmin);
+            mainWindow.setMapEditorExtension(this.mapEditorExtension);
             mainWindow.constructUI();
         }
         mainWindow.setVisible(true);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/Activator.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/Activator.java
@@ -28,9 +28,10 @@ import org.orbisgis.corejdbc.DataManager;
 import org.orbisgis.mainframe.api.MainFrameAction;
 import org.orbisgis.mapcomposer.view.ui.MainWindow;
 import org.orbisgis.mapcomposer.view.utils.MapComposerIcon;
-import org.orbisgis.mapeditor.map.MapEditor;
 import org.orbisgis.mapeditorapi.MapEditorExtension;
 import org.orbisgis.sif.components.actions.DefaultAction;
+import org.orbisgis.sif.edition.EditableElement;
+import org.orbisgis.sif.edition.Editor;
 import org.orbisgis.wkguiapi.ViewWorkspace;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -54,7 +55,7 @@ import java.util.List;
  */
 
 @Component
-public class Activator implements MainFrameAction {
+public class Activator implements MainFrameAction, Editor {
 
     public static final String MENU_MAPCOMPOSER = "MapComposer";
 
@@ -166,5 +167,20 @@ public class Activator implements MainFrameAction {
             mainWindow.getCompositionArea().configure((Integer) properties.get("unit"));
             mainWindow.configure((byte[]) properties.get("layout"));
         }
+    }
+
+    @Override
+    public boolean match(EditableElement editableElement) {
+        return false;
+    }
+
+    @Override
+    public EditableElement getEditableElement() {
+        return mainWindow;
+    }
+
+    @Override
+    public void setEditableElement(EditableElement editableElement) {
+
     }
 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/CompositionAreaController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/CompositionAreaController.java
@@ -499,4 +499,16 @@ public class CompositionAreaController {
     public JComponent getCompositionJPanel(GraphicalElement ge) {
         return elementJPanelMap.get(ge);
     }
+
+    /**
+     * Returns the list of GraphicalElement ordered by z-index (useful for exporting).
+     * @return The list of GraphicalElement ordered by z-index.
+     */
+    public Stack<GraphicalElement> getOrderedByZindexGeList(){
+        Stack<GraphicalElement> geStack = new Stack<>();
+        for(int i=zIndexStack.size()-1; i>=0; i--) {
+            geStack.add(zIndexStack.get(i));
+        }
+        return geStack;
+    }
 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/CompositionAreaController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/CompositionAreaController.java
@@ -281,8 +281,10 @@ public class CompositionAreaController {
             ((GERefresh)ge).refresh();
         RenderWorker worker = new RenderWorker(elementJPanelMap.get(ge), mainController.getGEManager().getRenderer(ge.getClass()), ge);
         executorService.submit(worker);
-        if(ge instanceof Document)
+        if(ge instanceof Document) {
             compositionArea.setDocumentDimension(new Dimension(ge.getWidth(), ge.getHeight()));
+            compositionArea.setInchOrCom(((Document)ge).getUnit());
+        }
     }
 
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/GEController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/GEController.java
@@ -86,6 +86,7 @@ public class GEController {
     public void modifySelectedGE(){
         for(GraphicalElement ge : selectedGE)
             modifyGE(ge);
+        mainController.getMainWindow().setModified(true);
     }
 
     /**
@@ -99,6 +100,7 @@ public class GEController {
             ((GERefresh)ge).refresh();
         mainController.getCompositionAreaController().modifyCompositionJPanel(ge);
         mainController.getUIController().refreshSpin();
+        mainController.getMainWindow().setModified(true);
     }
 
     /**
@@ -134,6 +136,7 @@ public class GEController {
             }
         }
         toBeSet = new ArrayList<>();
+        mainController.getMainWindow().setModified(true);
     }
 
     /**
@@ -165,6 +168,7 @@ public class GEController {
     public void removeSelectedGE(){
         listGE.removeAll(selectedGE);
         selectedGE=new ArrayList<>();
+        mainController.getMainWindow().setModified(true);
     }
 
     /**
@@ -181,6 +185,7 @@ public class GEController {
     public void removeAllGE() {
         selectedGE = new ArrayList<>();
         listGE = new ArrayList<>();
+        mainController.getMainWindow().setModified(true);
     }
 
     /**
@@ -190,6 +195,7 @@ public class GEController {
     public void removeGE(GraphicalElement ge) {
         selectedGE.remove(ge);
         listGE.remove(ge);
+        mainController.getMainWindow().setModified(true);
     }
 
     /**
@@ -204,6 +210,7 @@ public class GEController {
         selectedGE.add(ge);
         mainController.getCompositionAreaController().changeZIndex(CompositionAreaController.ZIndex.TO_FRONT);
         selectedGE = temp;
+        mainController.getMainWindow().setModified(true);
     }
 
     /**
@@ -233,6 +240,7 @@ public class GEController {
             }
         }
         modifySelectedGE();
+        mainController.getMainWindow().setModified(true);
     }
 
     /**
@@ -274,6 +282,7 @@ public class GEController {
         } catch (InstantiationException | IllegalAccessException ex) {
             LoggerFactory.getLogger(MainController.class).error(ex.getMessage());
         }
+        mainController.getMainWindow().setModified(true);
     }
 
     /**
@@ -332,6 +341,7 @@ public class GEController {
         }
         mainController.getCompositionAreaController().setOverlayMode(CompositionAreaOverlay.Mode.NONE);
         newGE=null;
+        mainController.getMainWindow().setModified(true);
     }
 
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/GEController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/GEController.java
@@ -26,6 +26,7 @@ package org.orbisgis.mapcomposer.controller;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.RefreshCA;
+import org.orbisgis.mapcomposer.model.graphicalelement.element.Document;
 import org.orbisgis.mapcomposer.model.graphicalelement.element.illustration.SimpleIllustrationGE;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GEProperties;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GERefresh;
@@ -283,6 +284,9 @@ public class GEController {
         if(winEvent.getSource() instanceof SIFDialog && newGE != null) {
             SIFDialog sifDialog = (SIFDialog) winEvent.getSource();
             if(sifDialog.isAccepted()) {
+                if(newGE instanceof Document){
+                    ((Document)newGE).refresh();
+                }
                 //If the newGE is a Document GE, then draw it immediately
                 if(newGE instanceof GEProperties && !((GEProperties)newGE).isDrawnByUser()){
                     mainController.addGE(newGE);
@@ -303,7 +307,8 @@ public class GEController {
                         }
                     }
                     mainController.getCompositionAreaController().setOverlayMode(CompositionAreaOverlay.Mode.NEW_GE);
-                    mainController.getCompositionAreaController().setOverlayMessage(i18n.tr("Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height ratio"));
+                    mainController.getCompositionAreaController().setOverlayMessage(i18n.tr("Now you can draw the " +
+                            "GraphicalElement. Hold SHIFT to keep the width/height ratio"));
                 }
 
                 List<GraphicalElement> list = new ArrayList<>();

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/GEController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/GEController.java
@@ -26,7 +26,6 @@ package org.orbisgis.mapcomposer.controller;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.RefreshCA;
-import org.orbisgis.mapcomposer.model.graphicalelement.element.Document;
 import org.orbisgis.mapcomposer.model.graphicalelement.element.illustration.SimpleIllustrationGE;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GEProperties;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GERefresh;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/GEController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/GEController.java
@@ -284,9 +284,6 @@ public class GEController {
         if(winEvent.getSource() instanceof SIFDialog && newGE != null) {
             SIFDialog sifDialog = (SIFDialog) winEvent.getSource();
             if(sifDialog.isAccepted()) {
-                if(newGE instanceof Document){
-                    ((Document)newGE).refresh();
-                }
                 //If the newGE is a Document GE, then draw it immediately
                 if(newGE instanceof GEProperties && !((GEProperties)newGE).isDrawnByUser()){
                     mainController.addGE(newGE);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/IOController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/IOController.java
@@ -42,6 +42,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Stack;
 
 /**
  * This controller manage the save, load and export actions.
@@ -115,12 +116,12 @@ public class IOController {
 
     /**
      * Exports the document into the format selected in the export dialog window (SaveFilePanel class)
-     * @param listGEToExport List of GraphicalElement to export.
+     * @param stackGEToExport Stack of GraphicalElement to export.
      * @param progressBar Progress bar where should be shown the progression. Can be null.
      */
-    public void export(List<GraphicalElement> listGEToExport, JProgressBar progressBar){
+    public void export(Stack<GraphicalElement> stackGEToExport, JProgressBar progressBar){
         //Display the export configuration dialog
-        UIDialogExportConfiguration uiDialogExportConfiguration = new UIDialogExportConfiguration(listGEToExport, geManager);
+        UIDialogExportConfiguration uiDialogExportConfiguration = new UIDialogExportConfiguration(stackGEToExport, geManager);
         //If the export configuration dialog is closed without validating it, exit the export
         if(!UIFactory.showDialog(uiDialogExportConfiguration, true, true))
             return;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/IOController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/IOController.java
@@ -68,13 +68,15 @@ public class IOController {
     /**
      * Runs saveProject function of the SaveHandler.
      * @param listGEToSave List of GraphicalElements to save.
+     * @return True if the document is successfully saved, false otherwise.
      */
-    public void saveDocument(List<GraphicalElement> listGEToSave){
+    public boolean saveDocument(List<GraphicalElement> listGEToSave){
         try {
-            saveNLoadHandler.saveProject(listGEToSave);
+            return saveNLoadHandler.saveProject(listGEToSave);
         } catch (NoSuchMethodException|IOException ex) {
             LoggerFactory.getLogger(MainController.class).error(ex.getMessage());
         }
+        return false;
     }
 
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/IOController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/IOController.java
@@ -71,7 +71,6 @@ public class IOController {
      */
     public void saveDocument(List<GraphicalElement> listGEToSave){
         try {
-            System.out.println(listGEToSave.size());
             saveNLoadHandler.saveProject(listGEToSave);
         } catch (NoSuchMethodException|IOException ex) {
             LoggerFactory.getLogger(MainController.class).error(ex.getMessage());

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/MainController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/MainController.java
@@ -33,6 +33,7 @@ import org.orbisgis.mapcomposer.model.graphicalelement.element.Document;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.*;
 import org.orbisgis.mapcomposer.model.graphicalelement.utils.GEManager;
 import org.orbisgis.mapcomposer.view.ui.MainWindow;
+import org.orbisgis.mapeditorapi.MapEditorExtension;
 import org.orbisgis.wkguiapi.ViewWorkspace;
 import org.xnap.commons.i18n.I18n;
 import org.xnap.commons.i18n.I18nFactory;
@@ -89,6 +90,8 @@ public class MainController{
     private ViewWorkspace viewWorkspace;
     /** DataManager of OrbisGIS */
     private DataManager dataManager;
+    /** MapEditorExtension comming from OrbisGIS */
+    private MapEditorExtension mapEditorExtension;
 
     /**
      * Main constructor.
@@ -442,6 +445,14 @@ public class MainController{
 
     public ViewWorkspace getViewWorkspace() {
         return viewWorkspace;
+    }
+
+    public MapEditorExtension getMapEditorExtension() {
+        return mapEditorExtension;
+    }
+
+    public void setMapEditorExtension(MapEditorExtension mapEditorExtension) {
+        this.mapEditorExtension = mapEditorExtension;
     }
 }
  

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/MainController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/MainController.java
@@ -127,6 +127,7 @@ public class MainController{
             //Enable the registering of edit actions
             undoingRedoing = false;
             uiController.refreshSpin();
+            mainWindow.setModified(true);
         }
         else
             compositionAreaController.setOverlayMessage(i18n.tr("Can't undo..;"));
@@ -143,6 +144,7 @@ public class MainController{
             //Enable the registering of edit actions
             undoingRedoing = false;
             uiController.refreshSpin();
+            mainWindow.setModified(true);
         }
         else
             compositionAreaController.setOverlayMessage(i18n.tr("Can't redo."));
@@ -353,7 +355,9 @@ public class MainController{
      * Saves the document (Save all the GE contained by the document).
      */
     public void saveDocument(){
-        ioController.saveDocument(geController.getGEList());
+        if(ioController.saveDocument(geController.getGEList())){
+            mainWindow.setModified(false);
+        }
     }
 
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/MainController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/MainController.java
@@ -395,7 +395,7 @@ public class MainController{
      * Export the actual document into PNG, PDF or HTML after refreshing all the GE
      */
     public void export(){
-        ioController.export(geController.getGEList(), mainWindow.getCompositionArea().getProgressionBar());
+        ioController.export(compositionAreaController.getOrderedByZindexGeList(), mainWindow.getCompositionArea().getProgressionBar());
     }
 
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -73,32 +73,29 @@ public class UIController {
 
 
     public void createDocument(){
-        //If the document already contain GraphicalElement, as before removing them
-        if(!mainController.getGEList().isEmpty()){
+        //If the document already contain GraphicalElement, ask before removing them
+        if(mainController.getMainWindow().isModified()){
             MultiInputPanel panel = new MultiInputPanel(i18n.tr("New document"));
             panel.addText(i18n.tr("Are you sure to create a new Document ?"));
             panel.addText(i18n.tr("Unsaved changes will be lost."));
-            SIFDialog dialog = UIFactory.getSimpleDialog(panel, mainController.getMainWindow(), true);
-            dialog.setVisible(true);
-            dialog.pack();
-            dialog.setAlwaysOnTop(true);
-            dialog.setLocationRelativeTo(mainController.getMainWindow());
-            dialog.addWindowListener(EventHandler.create(WindowListener.class, this, "instantiateDocument", "", "windowClosed"));
-        }
-        else{
-            instantiateDocument(null);
-        }
-    }
-
-    public void instantiateDocument(WindowEvent winEvent){
-        if(winEvent != null && winEvent.getSource() instanceof SIFDialog) {
-            if(!((SIFDialog)winEvent.getSource()).isAccepted()){
+            if(!UIFactory.showDialog(panel))
                 return;
-            }
         }
         mainController.removeAllGE();
         mainController.getMainWindow().repaint();
         mainController.getGEController().instantiateNewGE(Document.class);
+    }
+
+    public void openDocument(){
+        //If the document already contain GraphicalElement, ask before removing them
+        if(mainController.getMainWindow().isModified()){
+            MultiInputPanel panel = new MultiInputPanel(i18n.tr("Open document"));
+            panel.addText(i18n.tr("Are you sure to open an existing Document ?"));
+            panel.addText(i18n.tr("Unsaved changes will be lost."));
+            if(!UIFactory.showDialog(panel))
+                return;
+        }
+        mainController.loadDocument();
     }
 
     public void createMap(){

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -74,7 +74,8 @@ public class UIController {
 
     public void createDocument(){
         //If the document already contain GraphicalElement, ask before removing them
-        if(mainController.getMainWindow().isModified()){
+        if(!mainController.getGEList().isEmpty() &&
+                mainController.getMainWindow().isModified()){
             MultiInputPanel panel = new MultiInputPanel(i18n.tr("New document"));
             panel.addText(i18n.tr("Are you sure to create a new Document ?"));
             panel.addText(i18n.tr("Unsaved changes will be lost."));

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/UIController.java
@@ -250,11 +250,12 @@ public class UIController {
             toBeSet.add(doc);
             mainController.getGEController().setToBeSetList(toBeSet);
             //Create and show the properties dialog.
-            UIPanel panel = new UIDialogProperties(getCommonAttributes(toBeSet), mainController, false);
+            UIPanel panel = ((CustomConfigurationPanel)mainController.getGEManager().getRenderer(doc.getClass())).createConfigurationPanel(doc.deepCopy().getAllAttributes(), mainController, false);
             SIFDialog dialog = UIFactory.getSimpleDialog(panel, mainController.getMainWindow(), true);
             dialog.setVisible(true);
             dialog.pack();
             dialog.setAlwaysOnTop(true);
+            dialog.setLocationRelativeTo(mainController.getMainWindow());
         }
     }
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 
 import static java.lang.Math.cos;
 import static java.lang.Math.sin;
@@ -72,6 +73,9 @@ public class ExportImageThread implements ExportThread {
      **/
     private Map<GraphicalElement, Boolean> geIsVectorMap;
 
+    /** Stack of the GraphicalElement ordered by z index */
+    private Stack<GraphicalElement> geStack;
+
     /** JComboBox component containing the selected image type */
     private JComboBox<String> imageType;
 
@@ -80,6 +84,7 @@ public class ExportImageThread implements ExportThread {
      */
     public ExportImageThread(){
         this.geIsVectorMap = new HashMap<>();
+        this.geStack = new Stack<>();
     }
 
     @Override
@@ -101,7 +106,7 @@ public class ExportImageThread implements ExportThread {
             int geCount = 0;
             //Draw each GraphicalElement in the BufferedImage
             Graphics2D graphics2D = bi.createGraphics();
-            for(GraphicalElement ge : geIsVectorMap.keySet()){
+            for(GraphicalElement ge : geStack){
                 double rad = Math.toRadians(ge.getRotation());
                 //Width and Height of the rectangle containing the rotated bufferedImage
                 final double newWidth = Math.abs(cos(rad)*ge.getWidth())+Math.abs(sin(rad)*ge.getHeight());
@@ -164,10 +169,11 @@ public class ExportImageThread implements ExportThread {
     }
 
     @Override
-    public JComponent constructExportPanel(List<GraphicalElement> listGEToExport) {
-        for(GraphicalElement ge : listGEToExport){
+    public JComponent constructExportPanel(Stack<GraphicalElement> stackGEToExport) {
+        for(GraphicalElement ge : stackGEToExport){
             addData(ge, true);
         }
+        geStack = stackGEToExport;
 
         JPanel panelPNG = new JPanel(new MigLayout());
         panelPNG.add(new JLabel("Image type : "));

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java
@@ -165,6 +165,10 @@ public class ExportImageThread implements ExportThread {
 
     @Override
     public JComponent constructExportPanel(List<GraphicalElement> listGEToExport) {
+        for(GraphicalElement ge : listGEToExport){
+            addData(ge, true);
+        }
+
         JPanel panelPNG = new JPanel(new MigLayout());
         panelPNG.add(new JLabel("Image type : "));
         imageType = new JComboBox<>();

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java
@@ -176,11 +176,11 @@ public class ExportImageThread implements ExportThread {
         geStack = stackGEToExport;
 
         JPanel panelPNG = new JPanel(new MigLayout());
-        panelPNG.add(new JLabel("Image type : "));
+        panelPNG.add(new JLabel(i18n.tr("Image type : ")));
         imageType = new JComboBox<>();
-        imageType.addItem(I18n.marktr("png"));
-        imageType.addItem(I18n.marktr("jpg"));
-        imageType.addItem(I18n.marktr("gif"));
+        imageType.addItem(i18n.tr("png"));
+        imageType.addItem(i18n.tr("jpg"));
+        imageType.addItem(i18n.tr("gif"));
         panelPNG.add(imageType, "wrap");
         return panelPNG;
     }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 
 import static java.lang.Math.cos;
 import static java.lang.Math.sin;
@@ -87,6 +88,9 @@ public class ExportPDFThread implements ExportThread {
      * The boolean tells if the vector rendering should be use or not (if not use the raster rendering)
      **/
     private Map<GraphicalElement, Boolean> geIsVectorMap;
+
+    /** Stack of the GraphicalElement ordered by z index */
+    private Stack<GraphicalElement> geStack;
 
     /** Translation*/
     private static final I18n i18n = I18nFactory.getI18n(ExportPDFThread.class);
@@ -113,6 +117,7 @@ public class ExportPDFThread implements ExportThread {
      */
     public ExportPDFThread(){
         this.geIsVectorMap = new HashMap<>();
+        this.geStack = new Stack<>();
         this.listGEOnlyRaster = new ArrayList<>();
         this.listGEOnlyVector = new ArrayList<>();
     }
@@ -144,7 +149,7 @@ public class ExportPDFThread implements ExportThread {
             progressBar.setIndeterminate(true);
             int geCount = 0;
             //Draw each GraphicalElement in the BufferedImage
-            for(GraphicalElement ge : geIsVectorMap.keySet()){
+            for(GraphicalElement ge : geStack){
                 if((ge instanceof org.orbisgis.mapcomposer.model.graphicalelement.element.Document))
                     continue;
 
@@ -172,7 +177,15 @@ public class ExportPDFThread implements ExportThread {
                     ImageIO.write(bi, "png", baos);
                     Image image = Image.getInstance(baos.toByteArray());
                     image.setAbsolutePosition(ge.getX() + (ge.getWidth() - maxWidth) / 2, -ge.getY() + height - ge.getHeight() + (ge.getHeight() - maxHeight) / 2);
-                    pdfDocument.add(image);
+
+                    PdfTemplate pdfTemplate = cb.createTemplate(maxWidth, maxHeight);
+                    Graphics2D g2dTemplate = pdfTemplate.createGraphics(maxWidth, maxHeight);
+                    PdfLayer layer = new PdfLayer("layer", writer);
+                    cb.beginLayer(layer);
+                    g2dTemplate.drawImage(bi, 0, 0, null);
+                    cb.addTemplate(pdfTemplate, ge.getX() + (ge.getWidth() - maxWidth) / 2, -ge.getY() + height - ge.getHeight() + (ge.getHeight() - maxHeight) / 2);
+                    g2dTemplate.dispose();
+                    cb.endLayer();
                 }
 
                 progressBar.setIndeterminate(false);
@@ -225,14 +238,15 @@ public class ExportPDFThread implements ExportThread {
     }
 
     @Override
-    public JComponent constructExportPanel(List<GraphicalElement> listGEToExport) {
+    public JComponent constructExportPanel(Stack<GraphicalElement> StackGEToExport) {
         listVectorRadio = new ArrayList<>();
         listRasterRadio = new ArrayList<>();
         names = new ArrayList<>();
 
-        for(GraphicalElement ge : listGEToExport){
+        for(GraphicalElement ge : StackGEToExport){
             addData(ge, false);
         }
+        geStack = StackGEToExport;
 
         JPanel panelRasterVector = new JPanel(new MigLayout("hidemode 3"));
         panelRasterVector.setBorder(BorderFactory.createTitledBorder("Vector/Raster"));

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java
@@ -33,7 +33,6 @@ import com.itextpdf.text.pdf.PdfLayer;
 import com.itextpdf.text.pdf.PdfTemplate;
 import com.itextpdf.text.pdf.PdfWriter;
 import net.miginfocom.swing.MigLayout;
-import org.orbisgis.mapcomposer.controller.MainController;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;
 import org.orbisgis.mapcomposer.model.graphicalelement.utils.GEManager;
 import org.orbisgis.mapcomposer.view.graphicalelement.RendererRaster;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportThread.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportThread.java
@@ -29,8 +29,8 @@ import org.orbisgis.mapcomposer.model.graphicalelement.utils.GEManager;
 
 import javax.swing.JComponent;
 import javax.swing.JProgressBar;
-import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 
 /**
  * Interface to define thread exports. The export should be executed in the override method run()
@@ -76,10 +76,10 @@ public interface ExportThread extends Runnable {
      * This methods should construct an user interface to allow him to configure the different aspects of the export.
      * This interface should also uses addData() method to update the data to export.
      * Be careful, the GraphicalElement should be copied (deep copy) before registered to avoid concurrent modification during the export
-     * @param listGEToExport List of GraphicalElements to export.
+     * @param stackGEToExport Stack of GraphicalElements to export.
      * @return A JComponent containing all the swing component to allows the export configuration.
      */
-    public JComponent constructExportPanel(List<GraphicalElement> listGEToExport);
+    public JComponent constructExportPanel(Stack<GraphicalElement> stackGEToExport);
 
     /**
      * Returns the short name of the export. It will be displayed in the tab of the export configuration panel.

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/IntegerCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/IntegerCA.java
@@ -102,6 +102,7 @@ public class IntegerCA extends BaseCA<Integer> {
     @Override public void setValue(Integer value) {
         if(min<=value && value<=max || !limits)
             this.value=value;
+        System.out.println("" + this + value);
     }
 
     @Override public Integer getValue() {return value;}

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/IntegerCA.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/configurationattribute/attribute/IntegerCA.java
@@ -102,7 +102,6 @@ public class IntegerCA extends BaseCA<Integer> {
     @Override public void setValue(Integer value) {
         if(min<=value && value<=max || !limits)
             this.value=value;
-        System.out.println("" + this + value);
     }
 
     @Override public Integer getValue() {return value;}

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
@@ -163,7 +163,7 @@ public class Document extends SimpleGE implements GEProperties {
      * @return Unit of the document.
      */
     public Unit getUnit(){
-        return Unit.valueOf(unit.getSelected());
+        return Unit.getUnitFromName(unit.getSelected());
     }
     
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
@@ -173,10 +173,10 @@ public class Document extends SimpleGE implements GEProperties {
      */
     public void setFormat(Format f){
         format.select(f.getName());
-        if(!f.equals(Format.CUSTOM)) {
+        /*if(!f.equals(Format.CUSTOM)) {
             this.setWidth(f.getPixelWidth());
             this.setHeight(f.getPixelHeight());
-        }
+        }*/
     }
 
     /**
@@ -214,11 +214,11 @@ public class Document extends SimpleGE implements GEProperties {
             this.width.setValue((int) (this.width.getValue() * Unit.valueOf(unit.getSelected()).getConv()));
             this.height.setValue((int) (this.height.getValue() * Unit.valueOf(unit.getSelected()).getConv()));
         }*/
-        if(orientation.getSelected().equals(Orientation.LANDSCAPE.getName())){
+        /*if(orientation.getSelected().equals(Orientation.LANDSCAPE.getName())){
             int width = this.getWidth();
             this.setWidth(this.getHeight());
             this.setHeight(width);
-        }
+        }*/
     }
 
     @Override
@@ -274,7 +274,7 @@ public class Document extends SimpleGE implements GEProperties {
     public static enum Format{
         A4(210, 297, I18n.marktr("A4")),
         A3(297, 420, I18n.marktr("A3")),
-        CUSTOM(0, 0, I18n.marktr("Custom"));
+        CUSTOM(0, 0, I18n.marktr("CUSTOM"));
         /**Width of the format*/
         private int w;
         /**Height of the format*/

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
@@ -104,31 +104,6 @@ public class Document extends SimpleGE implements GEProperties {
     public boolean isEditedByMouse() {
         return false;
     }
-
-    /** Enumeration of the orientation possibilities : portrait or landscape.*/
-    public enum Orientation{
-        PORTRAIT(I18n.marktr("Portrait")),
-        LANDSCAPE(I18n.marktr("Landscape"));
-
-        /** Orientation name */
-        private String name;
-
-        /**
-         * Main constructor.
-         * @param name Name of the orientation.
-         */
-        private Orientation(String name){
-            this.name = name;
-        }
-
-        /**
-         * Returns the name of the orientation.
-         * @return The name of the orientation.
-         */
-        public String getName(){
-            return name;
-        }
-    }
     
     /**
      * Main constructor.
@@ -149,10 +124,10 @@ public class Document extends SimpleGE implements GEProperties {
         format.add(Format.CUSTOM.getName());
         setFormat(Format.A4);
         //Sets the unit CA
-        unit.add(Unit.MM.name());
-        unit.add(Unit.IN.name());
-        unit.add(Unit.PIXEL.name());
-        unit.select(Unit.MM.name());
+        unit.add(Unit.MM.getName());
+        unit.add(Unit.IN.getName());
+        unit.add(Unit.PIXEL.getName());
+        unit.select(Unit.MM.getName());
     }
     
     /**
@@ -173,10 +148,6 @@ public class Document extends SimpleGE implements GEProperties {
      */
     public void setFormat(Format f){
         format.select(f.getName());
-        /*if(!f.equals(Format.CUSTOM)) {
-            this.setWidth(f.getPixelWidth());
-            this.setHeight(f.getPixelHeight());
-        }*/
     }
 
     /**
@@ -207,18 +178,6 @@ public class Document extends SimpleGE implements GEProperties {
      */
     public Dimension getDimension(){
         return new Dimension(this.getWidth(), this.getHeight());
-    }
-
-    public void refresh() {
-        /*if(this.format.getSelected().equals(Format.CUSTOM.getName())) {
-            this.width.setValue((int) (this.width.getValue() * Unit.valueOf(unit.getSelected()).getConv()));
-            this.height.setValue((int) (this.height.getValue() * Unit.valueOf(unit.getSelected()).getConv()));
-        }*/
-        /*if(orientation.getSelected().equals(Orientation.LANDSCAPE.getName())){
-            int width = this.getWidth();
-            this.setWidth(this.getHeight());
-            this.setHeight(width);
-        }*/
     }
 
     @Override
@@ -331,12 +290,22 @@ public class Document extends SimpleGE implements GEProperties {
         public String getName(){
             return this.name;
         }
+
+        public static Format getUnitFromName(String name){
+            return valueOf(name.toUpperCase());
+        }
     }
 
+    /**
+     * Enumeration of the units that can be used
+     */
     public static enum Unit {
         MM((double)1/25.4, I18n.marktr("mm")),
         IN((double)1, I18n.marktr("in")),
         PIXEL(1, I18n.marktr("pixel"));
+
+        /** Human readable name of the unit.**/
+        private String name;
         /**
          * Width of the format
          */
@@ -368,10 +337,46 @@ public class Document extends SimpleGE implements GEProperties {
             } else {
                 this.conv = conv;
             }
+            this.name = name;
         }
 
         public double getConv(){
             return conv;
+        }
+
+        public String getName(){
+            return name;
+        }
+
+        public static Unit getUnitFromName(String name){
+            return valueOf(name.toUpperCase());
+        }
+    }
+
+    /**
+     * Enumeration of the orientation possibilities : portrait or landscape.
+     */
+    public enum Orientation{
+        PORTRAIT(I18n.marktr("Portrait")),
+        LANDSCAPE(I18n.marktr("Landscape"));
+
+        /** Orientation name */
+        private String name;
+
+        /**
+         * Main constructor.
+         * @param name Name of the orientation.
+         */
+        private Orientation(String name){
+            this.name = name;
+        }
+
+        /**
+         * Returns the name of the orientation.
+         * @return The name of the orientation.
+         */
+        public String getName(){
+            return name;
         }
     }
 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
@@ -173,8 +173,10 @@ public class Document extends SimpleGE implements GEProperties {
      */
     public void setFormat(Format f){
         format.select(f.getName());
-        this.setWidth(f.getPixelWidth());
-        this.setHeight(f.getPixelHeight());
+        if(!f.equals(Format.CUSTOM)) {
+            this.setWidth(f.getPixelWidth());
+            this.setHeight(f.getPixelHeight());
+        }
     }
 
     /**
@@ -208,10 +210,10 @@ public class Document extends SimpleGE implements GEProperties {
     }
 
     public void refresh() {
-        if(this.format.getSelected().equals(Format.CUSTOM.getName())) {
+        /*if(this.format.getSelected().equals(Format.CUSTOM.getName())) {
             this.width.setValue((int) (this.width.getValue() * Unit.valueOf(unit.getSelected()).getConv()));
             this.height.setValue((int) (this.height.getValue() * Unit.valueOf(unit.getSelected()).getConv()));
-        }
+        }*/
         if(orientation.getSelected().equals(Orientation.LANDSCAPE.getName())){
             int width = this.getWidth();
             this.setWidth(this.getHeight());

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java
@@ -30,6 +30,7 @@ import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.Configur
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GEProperties;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;
 import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
 import java.awt.Dimension;
 import java.lang.reflect.InvocationTargetException;
@@ -56,6 +57,9 @@ public class Document extends SimpleGE implements GEProperties {
 
     /**Name of the document*/
     private StringCA name;
+
+    /** Translation*/
+    private static final I18n i18n = I18nFactory.getI18n(Document.class);
 
     /** Displayed name of the orientation*/
     public static final String sOrientation = I18n.marktr("Orientation");
@@ -233,7 +237,7 @@ public class Document extends SimpleGE implements GEProperties {
     public static enum Format{
         A4(210, 297, I18n.marktr("A4")),
         A3(297, 420, I18n.marktr("A3")),
-        CUSTOM(0, 0, I18n.marktr("CUSTOM"));
+        CUSTOM(0, 0, I18n.marktr("Custom"));
         /**Width of the format*/
         private int w;
         /**Height of the format*/
@@ -291,8 +295,13 @@ public class Document extends SimpleGE implements GEProperties {
             return this.name;
         }
 
-        public static Format getUnitFromName(String name){
-            return valueOf(name.toUpperCase());
+        public static Format getFormatFromName(String name){
+            for(Format f : Format.values()) {
+                if(f.getName().equals(name)){
+                    return f;
+                }
+            }
+            return null;
         }
     }
 
@@ -302,14 +311,14 @@ public class Document extends SimpleGE implements GEProperties {
     public static enum Unit {
         MM((double)1/25.4, I18n.marktr("mm")),
         IN((double)1, I18n.marktr("in")),
-        PIXEL(1, I18n.marktr("pixel"));
+        PIXEL(0, I18n.marktr("pixel"));
 
         /** Human readable name of the unit.**/
         private String name;
         /**
          * Width of the format
          */
-        private double conv;
+        private double ratioToPixel;
 
         /**
          * DPI of the screen. As java don't detect well the dpi, it is set manually.
@@ -319,7 +328,7 @@ public class Document extends SimpleGE implements GEProperties {
         /**
          * Main constructor.
          */
-        private Unit(double conv, String name) {
+        private Unit(double ratioToPixel, String name) {
             //To be run on a server (no GUI), try to get the default Toolkit.
             //If it is not possible use a default value for the screen resolution.
             try {
@@ -332,24 +341,42 @@ public class Document extends SimpleGE implements GEProperties {
             } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | ClassNotFoundException e) {
                 dpi = 96;
             }
-            if (!name.equals("pixel")) {
-                this.conv = conv * dpi;
+            if (ratioToPixel != 0) {
+                this.ratioToPixel = ratioToPixel * dpi;
             } else {
-                this.conv = conv;
+                this.ratioToPixel = 1;
             }
             this.name = name;
         }
 
-        public double getConv(){
-            return conv;
+        /**
+         * Returns the conversion ratio (unit * ratio = value in pixel).
+         * @return The conversion ratio
+         */
+        public double getRatioToPixel(){
+            return ratioToPixel;
         }
 
+        /**
+         * Returns the human readable name of the unit.
+         * @return The human readable name
+         */
         public String getName(){
             return name;
         }
 
+        /**
+         * Returns the unit corresponding to the given name.
+         * @param name Name of the unit.
+         * @return The unit corresponding to the name.
+         */
         public static Unit getUnitFromName(String name){
-            return valueOf(name.toUpperCase());
+            for(Unit u : Unit.values()) {
+                if(u.getName().equals(name)){
+                    return u;
+                }
+            }
+            return null;
         }
     }
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java
@@ -44,32 +44,32 @@ import java.util.List;
  */
 public abstract class SimpleGE implements GraphicalElement{
     /** x position of the GE.*/
-    private IntegerCA x;
+    protected IntegerCA x;
     /** y position of the GE.*/
-    private IntegerCA y;
+    protected IntegerCA y;
     /** Inclination of the GE.*/
-    private IntegerCA rotation;
+    protected IntegerCA rotation;
     /** Height of the GE.*/
-    private IntegerCA height;
+    protected IntegerCA height;
     /** Width of the GE.*/
-    private IntegerCA width;
+    protected IntegerCA width;
     /** Z index of the GE.*/
-    private IntegerCA z;
+    protected IntegerCA z;
 
     /**Displayed name of the x position*/
-    private static final String sX = I18n.marktr("x");
+    public static final String sX = I18n.marktr("x");
 
     /**Displayed name of the y position*/
-    private static final String sY = I18n.marktr("y");
+    public static final String sY = I18n.marktr("y");
 
     /**Displayed name of the rotation*/
-    private static final String sRotation = I18n.marktr("Rotation");
+    public static final String sRotation = I18n.marktr("Rotation");
 
     /**Displayed name of the height*/
-    private static final String sHeight = I18n.marktr("Height");
+    public static final String sHeight = I18n.marktr("Height");
 
     /**Displayed name of the width*/
-    private static final String sWidth = I18n.marktr("Width");
+    public static final String sWidth = I18n.marktr("Width");
     
     /**
      * Main constructor.

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java
@@ -56,6 +56,9 @@ public abstract class SimpleGE implements GraphicalElement{
     /** Z index of the GE.*/
     protected IntegerCA z;
 
+    /** Translation*/
+    private static final I18n i18n = I18nFactory.getI18n(SimpleGE.class);
+
     /**Displayed name of the x position*/
     public static final String sX = I18n.marktr("x");
 

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java
@@ -31,6 +31,7 @@ import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.Configur
 import org.orbisgis.mapcomposer.model.graphicalelement.element.SimpleGE;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;
 import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
 import java.awt.Color;
 import java.util.ArrayList;
@@ -47,42 +48,42 @@ public class SimpleShapeGE extends SimpleGE {
     /**
      * Name of the line border.
      */
-    public static final String LineBorder = "Line";
+    public static final String LineBorder = I18n.marktr("Line");
 
     /**
      * Name of the empty border.
      */
-    public static final String EmptyBorder = "Empty";
+    public static final String EmptyBorder = I18n.marktr("Empty");
 
     /**
      * Name of the shape color.
      */
-    public static final String sShapeColor = "Shape color";
+    public static final String sShapeColor = I18n.marktr("Shape color");
 
     /**
      * Name of the shape alpha.
      */
-    public static final String sShapeAlpha = "Shape alpha";
+    public static final String sShapeAlpha = I18n.marktr("Shape alpha");
 
     /**
      * Name of the border width.
      */
-    public static final String sBorderWidth = "Border width";
+    public static final String sBorderWidth = I18n.marktr("Border width");
 
     /**
      * Name of the border alpha.
      */
-    public static final String sBorderAlpha = "Border alpha";
+    public static final String sBorderAlpha = I18n.marktr("Border alpha");
 
     /**
      * Name of the border color.
      */
-    public static final String sBorderColor = "Border color";
+    public static final String sBorderColor = I18n.marktr("Border color");
 
     /**
      * Name of the border style.
      */
-    public static final String sBorderStyle = "Border style";
+    public static final String sBorderStyle = I18n.marktr("Border style");
 
     /**
      * Configuration attribute of the shape color.

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java
@@ -84,6 +84,7 @@ public class TextElement extends SimpleGE implements GEProperties{
     /** Displayed name of the font size*/
     public static final String sFontSize = I18n.marktr("Font size");
 
+
     /**
      * Public main constructor.
      */
@@ -110,6 +111,16 @@ public class TextElement extends SimpleGE implements GEProperties{
         this.style.add(Style.ITALIC.name());
         this.style.add(Style.BOLD.name());
         this.style.select(Style.PLAIN.name());
+
+
+        /** Mark for translation Font style strings **/
+        I18n.marktr("PLAIN");
+        I18n.marktr("ITALIC");
+        I18n.marktr("BOLD");
+        /** Mark for translation Text alignment strings **/
+        I18n.marktr("LEFT");
+        I18n.marktr("CENTER");
+        I18n.marktr("RIGHT");
     }
 
     @Override
@@ -311,7 +322,7 @@ public class TextElement extends SimpleGE implements GEProperties{
     /**
      * Enumeration for the text alignment.
      */
-    public static enum Alignment{ LEFT, CENTER, RIGHT; }
+    public static enum Alignment{ LEFT, CENTER, RIGHT }
     
     /**
      * Enumeration for the text font style.

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java
@@ -235,17 +235,20 @@ public class SaveAndLoadHandler extends DefaultHandler {
     /**
      * Open a file chooser window and save the given list of GraphicalElement in the selected file.
      * @param list List of GraphicalElement to save
+     * @return True if the document is saved, false otherwise.
      * @throws IOException
      * @throws NoSuchMethodException
      */
-    public void saveProject(List<GraphicalElement> list) throws IOException, NoSuchMethodException {
+    public boolean saveProject(List<GraphicalElement> list) throws IOException, NoSuchMethodException {
         SaveFilePanel saveFilePanel = new SaveFilePanel("SaveAndLoadHandler", i18n.tr("Save document"));
         saveFilePanel.addFilter(new String[]{"xml"}, i18n.tr("XML save files"));
         saveFilePanel.loadState();
 
         if(UIFactory.showDialog(saveFilePanel)){
             save(list, saveFilePanel.getSelectedFile().getAbsolutePath());
+            return true;
         }
+        return false;
     }
 
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java
@@ -28,6 +28,8 @@ import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.Configur
 import org.orbisgis.mapcomposer.model.configurationattribute.attribute.ColorCA;
 import org.orbisgis.mapcomposer.view.utils.ColorChooser;
 import org.orbisgis.sif.UIFactory;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
 import java.awt.event.ActionListener;
 import java.beans.EventHandler;
@@ -48,11 +50,14 @@ import javax.swing.*;
  */
 public class ColorRenderer implements CARenderer{
 
+    /** Translation*/
+    private static final I18n i18n = I18nFactory.getI18n(ColorRenderer.class);
+
     @Override
     public JComponent createJComponentFromCA(ConfigurationAttribute ca) {
         final ColorCA colorCA = (ColorCA)ca;
 
-        JButton button = new JButton("Text demo");
+        JButton button = new JButton(i18n.tr("Text demo"));
         //Display the color in the button background
         button.setBackground(colorCA.getValue());
         //On clicking on the button, open a color chooser

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/MapImageListRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/MapImageListRenderer.java
@@ -57,8 +57,10 @@ public class MapImageListRenderer implements CARenderer{
         //Create a MapImage list
         List<ContainerItem<MapImage>> listContainer = new ArrayList<>();
         for(MapImage mapImage : milka.getValue()){
-            if(mapImage != null) {
-                listContainer.add(new ContainerItem<>(mapImage, mapImage.getOwsMapContext().getTitle()));
+            if(mapImage != null && mapImage.getOwsMapContext() != null) {
+                if(mapImage.getOwsMapContext().getTitle() != null) {
+                    listContainer.add(new ContainerItem<>(mapImage, mapImage.getOwsMapContext().getTitle()));
+                }
             }
         }
         //Adds a null MapImage

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceListRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceListRenderer.java
@@ -26,6 +26,9 @@ package org.orbisgis.mapcomposer.view.configurationattribute;
 
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;
 import org.orbisgis.mapcomposer.model.configurationattribute.attribute.SourceListCA;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
+
 import java.awt.FlowLayout;
 import java.awt.event.ActionListener;
 import java.beans.EventHandler;
@@ -44,11 +47,17 @@ import javax.swing.*;
  */
 public class SourceListRenderer implements CARenderer{
 
+    /** Translation*/
+    private static final I18n i18n = I18nFactory.getI18n(SourceListRenderer.class);
+
     @Override
     public JComponent createJComponentFromCA(ConfigurationAttribute ca) {
         SourceListCA sourceListCA = (SourceListCA)ca;
 
-        JComboBox<String> jcb = new JComboBox(sourceListCA.getValue().toArray(new String[0]));
+        JComboBox<String> jcb = new JComboBox();
+        for(Object o : sourceListCA.getValue()){
+            jcb.addItem(i18n.tr(o.toString()));
+        }
         jcb.addActionListener(EventHandler.create(ActionListener.class, sourceListCA, "select", "source.selectedItem"));
         //Display the SourceListCA into a JComboBox
         jcb.setSelectedItem(sourceListCA.getSelected());

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java
@@ -85,15 +85,17 @@ public class SourceRenderer implements CARenderer{
             jtf.setText(new File(sourceCA.getValue()).getName());
         else {
             //Load the last path use in a sourceCA
-            OpenFilePanel openFilePanel = new OpenFilePanel("ConfigurationAttribute.SourceCA", i18n.tr("Select source"));
-            openFilePanel.addFilter(new String[]{"*"}, "All files");
+            OpenFilePanel openFilePanel = new OpenFilePanel("ConfigurationAttribute.SourceCA", i18n.tr
+                    ("Select " +
+                    "source"));
+            openFilePanel.addFilter(new String[]{"*"}, i18n.tr("All files"));
             openFilePanel.loadState();
             jtf.setText(openFilePanel.getCurrentDirectory().getAbsolutePath());
         }
 
         component.add(jtf);
         //Create the button Browse
-        JButton button = new JButton("Browse");
+        JButton button = new JButton(i18n.tr("Browse"));
         //"Save" the sourceCA and the JTextField in the button
         button.putClientProperty("SourceCA", sourceCA);
         button.putClientProperty("JTextField", jtf);
@@ -109,8 +111,9 @@ public class SourceRenderer implements CARenderer{
      * @param event
      */
     public void openLoadPanel(ActionEvent event){
-        OpenFilePanel openFilePanel = new OpenFilePanel("ConfigurationAttribute.SourceCA", i18n.tr("Select source"));
-        openFilePanel.addFilter(new String[]{"*"}, "All files");
+        OpenFilePanel openFilePanel = new OpenFilePanel("ConfigurationAttribute.SourceCA", i18n.tr("Select " +
+                "source"));
+        openFilePanel.addFilter(new String[]{"*"}, i18n.tr("All files"));
         openFilePanel.loadState();
         if (UIFactory.showDialog(openFilePanel, true, true)) {
             JButton source = (JButton)event.getSource();

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/CircleRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/CircleRenderer.java
@@ -86,13 +86,11 @@ public class CircleRenderer implements GERenderer, RendererRaster, RendererVecto
         c = rectangle.getBorderColor();
         graphics2D.setColor(new Color(c.getRed(), c.getGreen(), c.getBlue(), rectangle.getBorderAlpha()*255/100));
         Stroke stroke = null;
-        switch(rectangle.getBorderStyle()){
-            case OvalGE.LineBorder:
-                stroke = new BasicStroke(rectangle.getBorderWidth(),
-                        BasicStroke.CAP_BUTT,
-                        BasicStroke.JOIN_MITER,
-                        1.0f, null, 0f);
-                break;
+        if(rectangle.getBorderStyle().equals(OvalGE.LineBorder)){
+            stroke = new BasicStroke(rectangle.getBorderWidth(),
+                    BasicStroke.CAP_BUTT,
+                    BasicStroke.JOIN_MITER,
+                    1.0f, null, 0f);
         }
         graphics2D.setStroke(stroke);
         graphics2D.drawOval(x - ge.getWidth()/2 + rectangle.getBorderWidth()/2,

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/CircleRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/CircleRenderer.java
@@ -74,10 +74,10 @@ public class CircleRenderer implements GERenderer, RendererRaster, RendererVecto
         //First draw the shape
         Color c = rectangle.getShapeColor();
         graphics2D.setColor(new Color(c.getRed(), c.getGreen(), c.getBlue(), rectangle.getShapeAlpha()*255/100));
-        graphics2D.fillOval(x - ge.getWidth()/2 + rectangle.getBorderWidth()/2,
-                y - ge.getHeight()/2 + rectangle.getBorderWidth()/2,
-                ge.getWidth() - rectangle.getBorderWidth(),
-                ge.getHeight() - rectangle.getBorderWidth());
+        graphics2D.fillOval(x - ge.getWidth()/2,
+                y - ge.getHeight()/2,
+                ge.getWidth(),
+                ge.getHeight());
 
         //Then if there is a border, draw it.
         if(rectangle.getBorderStyle().equals(OvalGE.EmptyBorder))

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
@@ -75,7 +75,8 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
     }
 
     @Override
-    public UIPanel createConfigurationPanel(List<ConfigurationAttribute> caList, MainController mainController, boolean enableLock){
+    public UIPanel createConfigurationPanel(List<ConfigurationAttribute> caList, MainController mainController,
+                                            boolean enableLock){
 
         //Create the UIDialogProperties that will be returned
         UIDialogProperties uid = new UIDialogProperties(mainController, enableLock);
@@ -97,18 +98,14 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
                 widthCA = (IntegerCA)ca;
 
         JLabel widthLabel = new JLabel(i18n.tr("width"));
-        /*JSpinner widthPixelSpinner = (JSpinner)mainController.getCAManager().getRenderer(widthCA)
-                .createJComponentFromCA
-                (widthCA);*/
-        JSpinner widthUnitSpinner = new JSpinner(new SpinnerNumberModel((int)widthCA.getValue(), 1, Integer.MAX_VALUE, 1));
-        widthUnitSpinner.putClientProperty("unit", unitBox);
-        //widthUnitSpinner.putClientProperty("spinner", widthPixelSpinner);
-        widthUnitSpinner.putClientProperty("ca", widthCA);
-        widthUnitSpinner.addChangeListener(EventHandler.create(ChangeListener.class, this, "onValueChange", "source"));
+        JSpinner widthSpinner = new JSpinner(new SpinnerNumberModel((int)widthCA.getValue(), 1, Integer.MAX_VALUE, 1));
+        //Adds the listener and the client properties needed.
+        widthSpinner.putClientProperty("unit", unitBox);
+        widthSpinner.putClientProperty("ca", widthCA);
+        widthSpinner.addChangeListener(EventHandler.create(ChangeListener.class, this, "onValueChange", "source"));
 
         widthLabel.setEnabled(false);
-        widthUnitSpinner.setEnabled(false);
-        //widthPixelSpinner.setVisible(false);
+        widthSpinner.setEnabled(false);
 
         //Get the ConfigurationAttribute of the height and its JComponent
         IntegerCA heightCA = null;
@@ -117,20 +114,17 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
                 heightCA = (IntegerCA)ca;
 
         JLabel heightLabel = new JLabel(i18n.tr("height"));
-        /*JSpinner heightPixelSpinner = (JSpinner)mainController.getCAManager().getRenderer(widthCA)
-                .createJComponentFromCA(heightCA);*/
-        JSpinner heightUnitSpinner = new JSpinner(new SpinnerNumberModel((int)heightCA.getValue(), 1, Integer.MAX_VALUE, 1));
-        heightUnitSpinner.putClientProperty("unit", unitBox);
-        //heightUnitSpinner.putClientProperty("spinner", heightPixelSpinner);
-        heightUnitSpinner.putClientProperty("ca", heightCA);
-        heightUnitSpinner.addChangeListener(EventHandler.create(ChangeListener.class, this, "onValueChange", "source"));
+        JSpinner heightSpinner = new JSpinner(new SpinnerNumberModel((int)heightCA.getValue(), 1, Integer.MAX_VALUE,1));
+        //Adds the listener and the client properties needed.
+        heightSpinner.putClientProperty("unit", unitBox);
+        heightSpinner.putClientProperty("ca", heightCA);
+        heightSpinner.addChangeListener(EventHandler.create(ChangeListener.class, this, "onValueChange", "source"));
 
         heightLabel.setEnabled(false);
-        heightUnitSpinner.setEnabled(false);
-        //heightPixelSpinner.setVisible(false);
+        heightSpinner.setEnabled(false);
 
-        unitBox.putClientProperty("widthUnitSpinner", widthUnitSpinner);
-        unitBox.putClientProperty("heightUnitSpinner", heightUnitSpinner);
+        unitBox.putClientProperty("widthSpinner", widthSpinner);
+        unitBox.putClientProperty("heightSpinner", heightSpinner);
 
         //Get the ConfigurationAttribute of the format and its JComponent
         SourceListCA formatCA = null;
@@ -141,29 +135,28 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
         JLabel formatName = new JLabel(formatCA.getName());
         uid.addComponent(formatName, formatCA, 0, 0, 1, 1);
 
-        //Adds an action listener to enable or disable the width and height spinner if the CUSTOM format is selected
-        JComboBox formatBox = (JComboBox)mainController.getCAManager().getRenderer(formatCA).createJComponentFromCA(formatCA);
+        //Adds the listener and the client properties needed.
+        JComboBox formatBox = (JComboBox)mainController.getCAManager().getRenderer(formatCA)
+                .createJComponentFromCA(formatCA);
         formatBox.putClientProperty("widthLabel", widthLabel);
-        formatBox.putClientProperty("widthUnitSpinner", widthUnitSpinner);
+        formatBox.putClientProperty("widthSpinner", widthSpinner);
         formatBox.putClientProperty("heightLabel", heightLabel);
-        formatBox.putClientProperty("heightUnitSpinner", heightUnitSpinner);
+        formatBox.putClientProperty("heightSpinner", heightSpinner);
         formatBox.putClientProperty("unitBox", unitBox);
         formatBox.putClientProperty("formatCA", formatCA);
-        formatBox.addActionListener(EventHandler.create(ActionListener.class, this, "selectItem", "source"));
+        formatBox.addActionListener(EventHandler.create(ActionListener.class, this, "onFormatChange", "source"));
 
         //Adds all the previous elements to the UIDialogProperties
         uid.addComponent(formatBox, formatCA, 1, 0, 2, 1);
         uid.addComponent(unitBox, unitCA, 0, 1, 2, 1);
 
         uid.addComponent(widthLabel, widthCA, 1, 1, 1, 1);
-        uid.addComponent(widthUnitSpinner, widthCA, 2, 1, 1, 1);
-        //uid.addComponent(widthPixelSpinner, widthCA, 3, 1, 1, 1);
+        uid.addComponent(widthSpinner, widthCA, 2, 1, 1, 1);
 
         uid.addComponent(heightLabel, heightCA, 1, 2, 1, 1);
-        uid.addComponent(heightUnitSpinner, heightCA, 2, 2, 1, 1);
-        //uid.addComponent(heightPixelSpinner, heightCA, 3, 2, 1, 1);
+        uid.addComponent(heightSpinner, heightCA, 2, 2, 1, 1);
 
-        //Find the OwsContext ConfigurationAttribute
+        //Find the orientation ConfigurationAttribute
         SourceListCA orientationCA = null;
         for(ConfigurationAttribute ca : caList)
             if(ca.getName().equals(Document.sOrientation))
@@ -172,10 +165,19 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
         JLabel orientationName = new JLabel(orientationCA.getName());
         uid.addComponent(orientationName, orientationCA, 0, 4, 1, 1);
 
-        JComboBox orientationBox = (JComboBox)mainController.getCAManager().getRenderer(orientationCA).createJComponentFromCA(orientationCA);
+        //Adds the listener and the client properties needed.
+        JComboBox orientationBox = (JComboBox)mainController.getCAManager().getRenderer(orientationCA)
+                .createJComponentFromCA(orientationCA);
         uid.addComponent(orientationBox, orientationCA, 1, 4, 2, 1);
+        orientationBox.putClientProperty("last", orientationBox.getSelectedItem());
+        orientationBox.putClientProperty("widthSpinner", widthSpinner);
+        orientationBox.putClientProperty("heightSpinner", heightSpinner);
+        orientationBox.addActionListener(EventHandler.create(
+                ActionListener.class, this,"onOrientationChange", "source"));
 
-        //Find the OwsContext ConfigurationAttribute
+        formatBox.putClientProperty("orientationBox", orientationBox);
+
+        //Find the name ConfigurationAttribute
         StringCA nameCA = null;
         for(ConfigurationAttribute ca : caList)
             if(ca.getName().equals(Document.sName))
@@ -184,52 +186,104 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
         JLabel nameName = new JLabel(nameCA.getName());
         uid.addComponent(nameName, nameCA, 0, 6, 1, 1);
 
-        JTextArea nameArea = (JTextArea)mainController.getCAManager().getRenderer(nameCA).createJComponentFromCA(nameCA);
+        JTextArea nameArea = (JTextArea)mainController.getCAManager().getRenderer(nameCA)
+                .createJComponentFromCA(nameCA);
         uid.addComponent(nameArea, nameCA, 0, 7, 4, 4);
+
+        //Sets the different comboBoxes
+        formatBox.setSelectedItem(formatBox.getSelectedItem());
+        unitBox.setSelectedItem(unitBox.getSelectedItem());
+        orientationBox.setSelectedItem(orientationBox.getSelectedItem());
 
         return uid;
     }
 
-    public void selectItem(Object item){
-        JComboBox formatBox = (JComboBox) item;
+    /**
+     * When the value of the document format is changed, set the width and height value with the one from the format.
+     * @param formatSpinner Spinner representing the format.
+     */
+    public void onFormatChange(Object formatSpinner){
+        JComboBox formatBox = (JComboBox) formatSpinner;
 
-        JComboBox unitBox = (JComboBox) ((JComboBox) item).getClientProperty("unitBox");
+        JComboBox unitBox = (JComboBox) ((JComboBox) formatSpinner).getClientProperty("unitBox");
         Document.Unit unit = Document.Unit.valueOf((String)unitBox.getSelectedItem());
+        JComboBox orientationBox = (JComboBox) ((JComboBox) formatSpinner).getClientProperty("orientationBox");
+        JLabel widthLabel = (JLabel) formatBox.getClientProperty("widthLabel");
+        JSpinner widthSpinner = (JSpinner) formatBox.getClientProperty("widthSpinner");
+        JLabel heightLabel = (JLabel) formatBox.getClientProperty("heightLabel");
+        JSpinner heightSpinner = (JSpinner) formatBox.getClientProperty("heightSpinner");
 
+        //If the format selected is CUSTOM, enable the spinners
+        boolean isCustomSelected  = formatBox.getSelectedItem().equals(Document.Format.CUSTOM.getName());
+        widthLabel.setEnabled(isCustomSelected);
+        widthSpinner.setEnabled(isCustomSelected);
+        heightLabel.setEnabled(isCustomSelected);
+        heightSpinner.setEnabled(isCustomSelected);
+
+        double width;
+        double height;
+
+        //Sets the width and height according to the format
         if(formatBox.getSelectedItem().equals(Document.Format.CUSTOM.getName())) {
-            JLabel widthLabel = (JLabel) formatBox.getClientProperty("widthLabel");
-            widthLabel.setEnabled(true);
-            JSpinner widthSpinner = (JSpinner) formatBox.getClientProperty("widthUnitSpinner");
-            widthSpinner.setEnabled(true);
-            JLabel heightLabel = (JLabel) formatBox.getClientProperty("heightLabel");
-            heightLabel.setEnabled(true);
-            JSpinner heightSpinner = (JSpinner) formatBox.getClientProperty("heightUnitSpinner");
-            heightSpinner.setEnabled(true);
+            //If the format is custom, keep the previous width and height value
+            width = Double.parseDouble(widthSpinner.getValue().toString());
+            height = Double.parseDouble(heightSpinner.getValue().toString());
         }
-        else{
-            JLabel widthLabel = (JLabel) formatBox.getClientProperty("widthLabel");
-            widthLabel.setEnabled(false);
-            JSpinner widthSpinner = (JSpinner) formatBox.getClientProperty("widthUnitSpinner");
-            widthSpinner.setEnabled(false);
-            JLabel heightLabel = (JLabel) formatBox.getClientProperty("heightLabel");
-            heightLabel.setEnabled(false);
-            JSpinner heightSpinner = (JSpinner) formatBox.getClientProperty("heightUnitSpinner");
-            heightSpinner.setEnabled(false);
+        else {
+            if (orientationBox.getSelectedItem().equals(Document.Orientation.PORTRAIT.getName())){
+                width = Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelWidth() / unit.getConv();
+                height = Document.Format.valueOf((String)formatBox.getSelectedItem()).getPixelHeight() / unit.getConv();
+            }
+            else{
+                height = Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelWidth() / unit.getConv();
+                width = Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelHeight() / unit.getConv();
+            }
+        }
 
-            widthSpinner.setValue((int)(Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelWidth()
-                    /unit.getConv()));
-            heightSpinner.setValue((int)(Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelHeight()
-                    /unit.getConv()));
+        //Correct the values (round for millimeter, and two digits for inch)
+        if(unit.equals(Document.Unit.IN)){
+            widthSpinner.setValue( ((double) ((int)(width*100)) )/100 );
+            heightSpinner.setValue( ((double) ((int)(height * 100))) / 100);
+        }
+        if(unit.equals(Document.Unit.MM)){
+            widthSpinner.setValue((int)Math.round(width));
+            heightSpinner.setValue((int)Math.round(height));
+        }
+        unitBox.setSelectedItem(unitBox.getSelectedItem());
+    }
+
+    /**
+     * When the value of the document orientation is changed, invert width and height values.
+     * @param orientationSpinner Spinner representing the format.
+     */
+    public void onOrientationChange(Object orientationSpinner){
+        JComboBox orientation = (JComboBox) orientationSpinner;
+        //Verify if the selected orientation is different from the last selected one
+        if(!orientation.getSelectedItem().equals(orientation.getClientProperty("last"))) {
+            JSpinner widthSpinner = (JSpinner) orientation.getClientProperty("widthSpinner");
+            JSpinner heightSpinner = (JSpinner) orientation.getClientProperty("heightSpinner");
+            //Invert the width and the height
+            Object temp = widthSpinner.getValue();
+            widthSpinner.setValue(heightSpinner.getValue());
+            heightSpinner.setValue(temp);
+            //Store the new orientation
+            orientation.putClientProperty("last", orientation.getSelectedItem());
         }
     }
 
-    public void onUnitChange(Object item){
-        JComboBox unitBox = (JComboBox) item;
-        Document.Unit before = Document.Unit.valueOf((String) unitBox.getClientProperty("last"));
+    /**
+     * When the value of the document unit is changed, convert the width and height values.
+     * @param unitSpinner Spinner representing the format.
+     */
+    public void onUnitChange(Object unitSpinner){
+        JComboBox unitBox = (JComboBox) unitSpinner;
+        Document.Unit unitBefore = Document.Unit.valueOf((String) unitBox.getClientProperty("last"));
+        Document.Unit unitNow = Document.Unit.valueOf((String) unitBox.getSelectedItem());
 
-        JSpinner widthSpinner = (JSpinner) unitBox.getClientProperty("widthUnitSpinner");
-        JSpinner heightSpinner = (JSpinner) unitBox.getClientProperty("heightUnitSpinner");
+        JSpinner widthSpinner = (JSpinner) unitBox.getClientProperty("widthSpinner");
+        JSpinner heightSpinner = (JSpinner) unitBox.getClientProperty("heightSpinner");
 
+        //Get the actual width and height value
         double width = 1;
         if(widthSpinner.getValue() instanceof Double){
             width = (double)widthSpinner.getValue();
@@ -245,46 +299,49 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
             height = (int)heightSpinner.getValue();
         }
 
-        //convert values to the inch one
-        if(before.equals(Document.Unit.IN)){
-            width *=1;
-            height *=1;
-        }
+        //Convert the value to the pixel unit
+        width *= unitBefore.getConv();
+        height *= unitBefore.getConv();
 
-        //convert values to the inch one
-        if(before.equals(Document.Unit.MM)){
-            width *=1D/25.4;
-            height *=1D/25.4;
-        }
+        //Convert the pixel value to the new unit
+        width /= unitNow.getConv();
+        height /= unitNow.getConv();
 
-        //convert values to the inch one
-        if(Document.Unit.valueOf((String)unitBox.getSelectedItem()).equals(Document.Unit.IN)){
-            width *=1;
-            height *=1;
-        }
-
-        //convert values to the inch one
-        if(Document.Unit.valueOf((String)unitBox.getSelectedItem()).equals(Document.Unit.MM)){
-            width *=25.4;
-            height *=25.4;
-        }
-
-        if(unitBox.getSelectedItem().equals(Document.Unit.MM.name())) {
-            widthSpinner.setModel(new SpinnerNumberModel(width, 1, Integer.MAX_VALUE, 1));
-            heightSpinner.setModel(new SpinnerNumberModel(height, 1, Integer.MAX_VALUE, 1));
-            unitBox.putClientProperty("last", Document.Unit.MM.name());
-        }
-        if(unitBox.getSelectedItem().equals(Document.Unit.IN.name())) {
-            widthSpinner.setModel(new SpinnerNumberModel(width, 1, Integer.MAX_VALUE, 0.1));
-            heightSpinner.setModel(new SpinnerNumberModel(height, 1, Integer.MAX_VALUE, 0.1));
-            unitBox.putClientProperty("last", Document.Unit.IN.name());
+        //According to the unit set the width and height spinner model and store the new unit value
+        switch(unitNow){
+            case PIXEL:
+                width = (int)Math.round(width);
+                height = (int)Math.round(height);
+                widthSpinner.setModel(new SpinnerNumberModel(width, 1, Integer.MAX_VALUE, 1));
+                heightSpinner.setModel(new SpinnerNumberModel(height, 1, Integer.MAX_VALUE, 1));
+                unitBox.putClientProperty("last", Document.Unit.PIXEL.name());
+                break;
+            case MM:
+                width = (int)Math.round(width);
+                height = (int)Math.round(height);
+                widthSpinner.setModel(new SpinnerNumberModel(width, 1, Integer.MAX_VALUE, 1));
+                heightSpinner.setModel(new SpinnerNumberModel(height, 1, Integer.MAX_VALUE, 1));
+                unitBox.putClientProperty("last", Document.Unit.MM.name());
+                break;
+            case IN:
+                width = ((double) ((int)(width*100)) )/100;
+                height = ((double) ((int)(height * 100))) / 100;
+                widthSpinner.setModel(new SpinnerNumberModel(width, 1, Integer.MAX_VALUE, 0.1));
+                heightSpinner.setModel(new SpinnerNumberModel(height, 1, Integer.MAX_VALUE, 0.1));
+                unitBox.putClientProperty("last", Document.Unit.IN.name());
+                break;
         }
     }
 
-    public void onValueChange(Object item){
-        JSpinner unitSpinner = (JSpinner) item;
+    /**
+     * When the value of the width or height spinner is changed, set the corresponding IntegerCA value.
+     * @param spinner Width or height spinner.
+     */
+    public void onValueChange(Object spinner){
+        JSpinner unitSpinner = (JSpinner) spinner;
         String unit = (String) ((JComboBox) unitSpinner.getClientProperty("unit")).getSelectedItem();
         double value = 1;
+        //Get the value which can be Doudle or Integer
         if(unitSpinner.getValue() instanceof Double){
             value = (double)unitSpinner.getValue();
         }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
@@ -25,17 +25,25 @@
 package org.orbisgis.mapcomposer.view.graphicalelement;
 
 import org.orbisgis.mapcomposer.controller.MainController;
+import org.orbisgis.mapcomposer.model.configurationattribute.attribute.IntegerCA;
 import org.orbisgis.mapcomposer.model.configurationattribute.attribute.OwsContextCA;
 import org.orbisgis.mapcomposer.model.configurationattribute.attribute.SourceListCA;
+import org.orbisgis.mapcomposer.model.configurationattribute.attribute.StringCA;
 import org.orbisgis.mapcomposer.model.configurationattribute.interfaces.ConfigurationAttribute;
 import org.orbisgis.mapcomposer.model.graphicalelement.element.Document;
+import org.orbisgis.mapcomposer.model.graphicalelement.element.SimpleGE;
 import org.orbisgis.mapcomposer.model.graphicalelement.element.cartographic.MapImage;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;
 import org.orbisgis.mapcomposer.view.utils.UIDialogProperties;
 import org.orbisgis.sif.UIPanel;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
+import javax.swing.JSpinner;
+import javax.swing.JTextArea;
+import javax.swing.SpinnerNumberModel;
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.event.ActionListener;
@@ -50,6 +58,9 @@ import java.util.List;
  * @author Sylvain PALOMINOS
  */
 public class DocumentRenderer implements RendererRaster, RendererVector, CustomConfigurationPanel {
+
+    /** Object for the translation*/
+    private static final I18n i18n = I18nFactory.getI18n(DocumentRenderer.class);
 
     @Override
     public void drawGE(Graphics2D graphics2D, GraphicalElement ge) {
@@ -66,22 +77,71 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
     }
 
     @Override
-    public UIPanel createConfigurationPanel(List<ConfigurationAttribute> caList, MainController uic, boolean enableLock){
+    public UIPanel createConfigurationPanel(List<ConfigurationAttribute> caList, MainController mainController, boolean enableLock){
 
         //Create the UIDialogProperties that will be returned
-        UIDialogProperties uid = new UIDialogProperties(uic, enableLock);
+        UIDialogProperties uid = new UIDialogProperties(mainController, enableLock);
 
-        //Find the OwsContext ConfigurationAttribute
+        //Get the ConfigurationAttribute of the width and its JComponent
+        IntegerCA widthCA = null;
+        for(ConfigurationAttribute ca : caList)
+            if(ca.getName().equals(SimpleGE.sWidth))
+                widthCA = (IntegerCA)ca;
+
+        JLabel widthLabel = new JLabel(i18n.tr("width"));
+        JSpinner widthSpinner = (JSpinner)mainController.getCAManager().getRenderer(widthCA).createJComponentFromCA(widthCA);
+
+        widthLabel.setEnabled(false);
+        widthSpinner.setEnabled(false);
+
+        //Get the ConfigurationAttribute of the height and its JComponent
+        IntegerCA heightCA = null;
+        for(ConfigurationAttribute ca : caList)
+            if(ca.getName().equals(SimpleGE.sHeight))
+                heightCA = (IntegerCA)ca;
+
+        JLabel heightLabel = new JLabel(i18n.tr("height"));
+        JSpinner heightSpinner = (JSpinner)mainController.getCAManager().getRenderer(widthCA).createJComponentFromCA(heightCA);
+
+        heightLabel.setEnabled(false);
+        heightSpinner.setEnabled(false);
+
+        //Get the ConfigurationAttribute of the unit and its JComponent
+        SourceListCA unitCA = null;
+        for(ConfigurationAttribute ca : caList)
+            if(ca.getName().equals(Document.sUnit))
+                unitCA = (SourceListCA)ca;
+
+        JComboBox unitBox = (JComboBox)mainController.getCAManager().getRenderer(unitCA).createJComponentFromCA(unitCA);
+
+        //Get the ConfigurationAttribute of the format and its JComponent
         SourceListCA formatCA = null;
         for(ConfigurationAttribute ca : caList)
-            if(ca.getName().equals(Document.sOrientation))
+            if(ca.getName().equals(Document.sFormat))
                 formatCA = (SourceListCA)ca;
 
         JLabel formatName = new JLabel(formatCA.getName());
-        uid.addComponent(formatName, formatCA, 0, 1, 1, 1);
+        uid.addComponent(formatName, formatCA, 0, 0, 1, 1);
 
-        JComboBox formatBox = (JComboBox)uic.getCAManager().getRenderer(formatCA).createJComponentFromCA(formatCA);
-        uid.addComponent(formatBox, formatCA, 1, 1, 2, 1);
+        //Adds an action listener to enable or disable the width and height spinner if the CUSTOM format is selected
+        JComboBox formatBox = (JComboBox)mainController.getCAManager().getRenderer(formatCA).createJComponentFromCA(formatCA);
+        formatBox.putClientProperty("widthLabel", widthLabel);
+        formatBox.putClientProperty("widthSpinner", widthSpinner);
+        formatBox.putClientProperty("heightLabel", heightLabel);
+        formatBox.putClientProperty("heightSpinner", heightSpinner);
+        formatBox.putClientProperty("mainController", mainController);
+        formatBox.putClientProperty("formatCA", formatCA);
+        formatBox.addActionListener(EventHandler.create(ActionListener.class, this, "selectItem", "source"));
+
+        //Adds all the previous elements to the UIDialogProperties
+        uid.addComponent(formatBox, formatCA, 1, 0, 2, 1);
+        uid.addComponent(unitBox, unitCA, 0, 1, 2, 1);
+
+        uid.addComponent(widthLabel, widthCA, 1, 1, 1, 1);
+        uid.addComponent(widthSpinner, widthCA, 2, 1, 1, 1);
+
+        uid.addComponent(heightLabel, heightCA, 1, 2, 1, 1);
+        uid.addComponent(heightSpinner, heightCA, 2, 2, 1, 1);
 
         //Find the OwsContext ConfigurationAttribute
         SourceListCA orientationCA = null;
@@ -90,21 +150,53 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
                 orientationCA = (SourceListCA)ca;
 
         JLabel orientationName = new JLabel(orientationCA.getName());
-        uid.addComponent(orientationName, orientationCA, 0, 1, 1, 1);
+        uid.addComponent(orientationName, orientationCA, 0, 4, 1, 1);
 
-        JComboBox orientationBox = (JComboBox)uic.getCAManager().getRenderer(orientationCA).createJComponentFromCA(orientationCA);
-        uid.addComponent(orientationBox, orientationCA, 1, 1, 2, 1);
-        orientationBox.addActionListener(EventHandler.create(ActionListener.class, this, "selectItem", "source" +
-                ".selectedItem"));
+        JComboBox orientationBox = (JComboBox)mainController.getCAManager().getRenderer(orientationCA).createJComponentFromCA(orientationCA);
+        uid.addComponent(orientationBox, orientationCA, 1, 4, 2, 1);
+
+        //Find the OwsContext ConfigurationAttribute
+        StringCA nameCA = null;
+        for(ConfigurationAttribute ca : caList)
+            if(ca.getName().equals(Document.sName))
+                nameCA = (StringCA)ca;
+
+        JLabel nameName = new JLabel(nameCA.getName());
+        uid.addComponent(nameName, nameCA, 0, 6, 1, 1);
+
+        JTextArea nameArea = (JTextArea)mainController.getCAManager().getRenderer(nameCA).createJComponentFromCA(nameCA);
+        uid.addComponent(nameArea, nameCA, 0, 7, 4, 4);
 
         return uid;
     }
 
     public void selectItem(Object item){
-        if(item.equals(Document.Format.CUSTOM.getName())){
-            unitBox.isVisible(true);
-            widthBox.isVisible(true);
-            heightBox.isVisible(true);
+        JComboBox formatBox = (JComboBox) item;
+        if(formatBox.getSelectedItem().equals(Document.Format.CUSTOM.getName())) {
+            JLabel widthLabel = (JLabel) formatBox.getClientProperty("widthLabel");
+            widthLabel.setEnabled(true);
+            JSpinner widthSpinner = (JSpinner) formatBox.getClientProperty("widthSpinner");
+            widthSpinner.setEnabled(true);
+            JLabel heightLabel = (JLabel) formatBox.getClientProperty("heightLabel");
+            heightLabel.setEnabled(true);
+            JSpinner heightSpinner = (JSpinner) formatBox.getClientProperty("heightSpinner");
+            heightSpinner.setEnabled(true);
+
+            widthSpinner.setValue(50);
+            heightSpinner.setValue(50);
+        }
+        else{
+            JLabel widthLabel = (JLabel) formatBox.getClientProperty("widthLabel");
+            widthLabel.setEnabled(false);
+            JSpinner widthSpinner = (JSpinner) formatBox.getClientProperty("widthSpinner");
+            widthSpinner.setEnabled(false);
+            JLabel heightLabel = (JLabel) formatBox.getClientProperty("heightLabel");
+            heightLabel.setEnabled(false);
+            JSpinner heightSpinner = (JSpinner) formatBox.getClientProperty("heightSpinner");
+            heightSpinner.setEnabled(false);
+
+            widthSpinner.setValue(Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelWidth());
+            heightSpinner.setValue(Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelHeight());
         }
     }
 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
@@ -132,7 +132,7 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
             if(ca.getName().equals(Document.sFormat))
                 formatCA = (SourceListCA)ca;
 
-        JLabel formatName = new JLabel(formatCA.getName());
+        JLabel formatName = new JLabel(i18n.tr(formatCA.getName()));
         uid.addComponent(formatName, formatCA, 0, 0, 1, 1);
 
         //Adds the listener and the client properties needed.
@@ -162,7 +162,7 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
             if(ca.getName().equals(Document.sOrientation))
                 orientationCA = (SourceListCA)ca;
 
-        JLabel orientationName = new JLabel(orientationCA.getName());
+        JLabel orientationName = new JLabel(i18n.tr(orientationCA.getName()));
         uid.addComponent(orientationName, orientationCA, 0, 4, 1, 1);
 
         //Adds the listener and the client properties needed.
@@ -183,7 +183,7 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
             if(ca.getName().equals(Document.sName))
                 nameCA = (StringCA)ca;
 
-        JLabel nameName = new JLabel(nameCA.getName());
+        JLabel nameName = new JLabel(i18n.tr(nameCA.getName()));
         uid.addComponent(nameName, nameCA, 0, 6, 1, 1);
 
         JTextArea nameArea = (JTextArea)mainController.getCAManager().getRenderer(nameCA)
@@ -231,16 +231,16 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
         }
         else {
             if (orientationBox.getSelectedItem().equals(Document.Orientation.PORTRAIT.getName())){
-                width = Document.Format.getUnitFromName(
-                        (String) formatBox.getSelectedItem()).getPixelWidth() / unit.getConv();
-                height = Document.Format.getUnitFromName(
-                        (String) formatBox.getSelectedItem()).getPixelHeight() / unit.getConv();
+                width = Document.Format.getFormatFromName(
+                        (String) formatBox.getSelectedItem()).getPixelWidth() / unit.getRatioToPixel();
+                height = Document.Format.getFormatFromName(
+                        (String) formatBox.getSelectedItem()).getPixelHeight() / unit.getRatioToPixel();
             }
             else{
-                height = Document.Format.getUnitFromName(
-                        (String) formatBox.getSelectedItem()).getPixelWidth() / unit.getConv();
-                width = Document.Format.getUnitFromName(
-                        (String) formatBox.getSelectedItem()).getPixelHeight() / unit.getConv();
+                height = Document.Format.getFormatFromName(
+                        (String) formatBox.getSelectedItem()).getPixelWidth() / unit.getRatioToPixel();
+                width = Document.Format.getFormatFromName(
+                        (String) formatBox.getSelectedItem()).getPixelHeight() / unit.getRatioToPixel();
             }
         }
 
@@ -304,12 +304,12 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
         }
 
         //Convert the value to the pixel unit
-        width *= unitBefore.getConv();
-        height *= unitBefore.getConv();
+        width *= unitBefore.getRatioToPixel();
+        height *= unitBefore.getRatioToPixel();
 
         //Convert the pixel value to the new unit
-        width /= unitNow.getConv();
-        height /= unitNow.getConv();
+        width /= unitNow.getRatioToPixel();
+        height /= unitNow.getRatioToPixel();
 
         //According to the unit set the width and height spinner model and store the new unit value
         switch(unitNow){
@@ -345,7 +345,7 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
         JSpinner unitSpinner = (JSpinner) spinner;
         String unit = (String) ((JComboBox) unitSpinner.getClientProperty("unit")).getSelectedItem();
         double value = 1;
-        //Get the value which can be Doudle or Integer
+        //Get the value which can be Double or Integer
         if(unitSpinner.getValue() instanceof Double){
             value = (double)unitSpinner.getValue();
         }
@@ -353,6 +353,6 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
             value = (int)unitSpinner.getValue();
         }
         IntegerCA ca = (IntegerCA) unitSpinner.getClientProperty("ca");
-        ca.setValue((int)(value * Document.Unit.getUnitFromName(unit).getConv()));
+        ca.setValue((int)(value * Document.Unit.getUnitFromName(unit).getRatioToPixel()));
     }
 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java
@@ -206,7 +206,7 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
         JComboBox formatBox = (JComboBox) formatSpinner;
 
         JComboBox unitBox = (JComboBox) ((JComboBox) formatSpinner).getClientProperty("unitBox");
-        Document.Unit unit = Document.Unit.valueOf((String)unitBox.getSelectedItem());
+        Document.Unit unit = Document.Unit.getUnitFromName((String) unitBox.getSelectedItem());
         JComboBox orientationBox = (JComboBox) ((JComboBox) formatSpinner).getClientProperty("orientationBox");
         JLabel widthLabel = (JLabel) formatBox.getClientProperty("widthLabel");
         JSpinner widthSpinner = (JSpinner) formatBox.getClientProperty("widthSpinner");
@@ -231,12 +231,16 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
         }
         else {
             if (orientationBox.getSelectedItem().equals(Document.Orientation.PORTRAIT.getName())){
-                width = Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelWidth() / unit.getConv();
-                height = Document.Format.valueOf((String)formatBox.getSelectedItem()).getPixelHeight() / unit.getConv();
+                width = Document.Format.getUnitFromName(
+                        (String) formatBox.getSelectedItem()).getPixelWidth() / unit.getConv();
+                height = Document.Format.getUnitFromName(
+                        (String) formatBox.getSelectedItem()).getPixelHeight() / unit.getConv();
             }
             else{
-                height = Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelWidth() / unit.getConv();
-                width = Document.Format.valueOf((String) formatBox.getSelectedItem()).getPixelHeight() / unit.getConv();
+                height = Document.Format.getUnitFromName(
+                        (String) formatBox.getSelectedItem()).getPixelWidth() / unit.getConv();
+                width = Document.Format.getUnitFromName(
+                        (String) formatBox.getSelectedItem()).getPixelHeight() / unit.getConv();
             }
         }
 
@@ -277,8 +281,8 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
      */
     public void onUnitChange(Object unitSpinner){
         JComboBox unitBox = (JComboBox) unitSpinner;
-        Document.Unit unitBefore = Document.Unit.valueOf((String) unitBox.getClientProperty("last"));
-        Document.Unit unitNow = Document.Unit.valueOf((String) unitBox.getSelectedItem());
+        Document.Unit unitBefore = Document.Unit.getUnitFromName((String) unitBox.getClientProperty("last"));
+        Document.Unit unitNow = Document.Unit.getUnitFromName((String) unitBox.getSelectedItem());
 
         JSpinner widthSpinner = (JSpinner) unitBox.getClientProperty("widthSpinner");
         JSpinner heightSpinner = (JSpinner) unitBox.getClientProperty("heightSpinner");
@@ -314,21 +318,21 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
                 height = (int)Math.round(height);
                 widthSpinner.setModel(new SpinnerNumberModel(width, 1, Integer.MAX_VALUE, 1));
                 heightSpinner.setModel(new SpinnerNumberModel(height, 1, Integer.MAX_VALUE, 1));
-                unitBox.putClientProperty("last", Document.Unit.PIXEL.name());
+                unitBox.putClientProperty("last", Document.Unit.PIXEL.getName());
                 break;
             case MM:
                 width = (int)Math.round(width);
                 height = (int)Math.round(height);
                 widthSpinner.setModel(new SpinnerNumberModel(width, 1, Integer.MAX_VALUE, 1));
                 heightSpinner.setModel(new SpinnerNumberModel(height, 1, Integer.MAX_VALUE, 1));
-                unitBox.putClientProperty("last", Document.Unit.MM.name());
+                unitBox.putClientProperty("last", Document.Unit.MM.getName());
                 break;
             case IN:
                 width = ((double) ((int)(width*100)) )/100;
                 height = ((double) ((int)(height * 100))) / 100;
                 widthSpinner.setModel(new SpinnerNumberModel(width, 1, Integer.MAX_VALUE, 0.1));
                 heightSpinner.setModel(new SpinnerNumberModel(height, 1, Integer.MAX_VALUE, 0.1));
-                unitBox.putClientProperty("last", Document.Unit.IN.name());
+                unitBox.putClientProperty("last", Document.Unit.IN.getName());
                 break;
         }
     }
@@ -349,6 +353,6 @@ public class DocumentRenderer implements RendererRaster, RendererVector, CustomC
             value = (int)unitSpinner.getValue();
         }
         IntegerCA ca = (IntegerCA) unitSpinner.getClientProperty("ca");
-        ca.setValue((int)(value * Document.Unit.valueOf(unit).getConv()));
+        ca.setValue((int)(value * Document.Unit.getUnitFromName(unit).getConv()));
     }
 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/MapImageRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/MapImageRenderer.java
@@ -33,6 +33,8 @@ import org.orbisgis.mapcomposer.view.utils.Graphics2DRenderer;
 import org.orbisgis.mapcomposer.view.utils.MapComposerIcon;
 import org.orbisgis.mapcomposer.view.utils.UIDialogProperties;
 import org.orbisgis.sif.UIPanel;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
 import javax.swing.ImageIcon;
 import javax.swing.JComboBox;
@@ -50,6 +52,9 @@ import static java.lang.Math.sin;
  * @author Sylvain PALOMINOS
  */
 public class MapImageRenderer implements RendererRaster, RendererVector, CustomConfigurationPanel {
+
+    /** Object for the translation*/
+    private static final I18n i18n = I18nFactory.getI18n(MapImageRenderer.class);
 
     @Override
     public void drawGE(Graphics2D graphics2D, GraphicalElement ge) {
@@ -130,7 +135,7 @@ public class MapImageRenderer implements RendererRaster, RendererVector, CustomC
             if(ca.getName().equals(MapImage.sOWSC))
                 owscCA = (OwsContextCA)ca;
 
-        JLabel owscName = new JLabel(owscCA.getName());
+        JLabel owscName = new JLabel(i18n.tr(owscCA.getName()));
         uid.addComponent(owscName, owscCA, 0, 0, 1, 1);
 
         JComboBox owscBox = (JComboBox)uic.getCAManager().getRenderer(owscCA).createJComponentFromCA(owscCA);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/RectangleRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/RectangleRenderer.java
@@ -74,10 +74,10 @@ public class RectangleRenderer implements GERenderer, RendererRaster, RendererVe
         //First draw the shape
         Color c = rectangle.getShapeColor();
         graphics2D.setColor(new Color(c.getRed(), c.getGreen(), c.getBlue(), rectangle.getShapeAlpha()*255/100));
-        graphics2D.fillRect(x - ge.getWidth()/2 + rectangle.getBorderWidth()/2,
-                y - ge.getHeight()/2 + rectangle.getBorderWidth() / 2,
-                ge.getWidth() - rectangle.getBorderWidth(),
-                ge.getHeight() - rectangle.getBorderWidth());
+        graphics2D.fillRect(x - ge.getWidth()/2,
+                y - ge.getHeight()/2,
+                ge.getWidth(),
+                ge.getHeight());
 
         if(rectangle.getBorderStyle().equals(RectangleGE.EmptyBorder))
             return;

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/RectangleRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/RectangleRenderer.java
@@ -86,12 +86,10 @@ public class RectangleRenderer implements GERenderer, RendererRaster, RendererVe
         c = rectangle.getBorderColor();
         graphics2D.setColor(new Color(c.getRed(), c.getGreen(), c.getBlue(), rectangle.getBorderAlpha()*255/100));
         Stroke stroke = null;
-        switch(rectangle.getBorderStyle()){
-            case RectangleGE.LineBorder:
-                 stroke = new BasicStroke(rectangle.getBorderWidth(),
-                         BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER,
-                         1.0f, null, 0f);
-                break;
+        if(rectangle.getBorderStyle().equals(RectangleGE.LineBorder)){
+             stroke = new BasicStroke(rectangle.getBorderWidth(),
+                     BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER,
+                     1.0f, null, 0f);
         }
         graphics2D.setStroke(stroke);
         graphics2D.drawRect(x - ge.getWidth()/2 + rectangle.getBorderWidth()/2,

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/TextRenderer.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/graphicalelement/TextRenderer.java
@@ -34,6 +34,8 @@ import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalEleme
 import org.orbisgis.mapcomposer.model.graphicalelement.element.text.TextElement;
 import org.orbisgis.mapcomposer.view.utils.UIDialogProperties;
 import org.orbisgis.sif.UIPanel;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
 import javax.swing.*;
 import java.awt.*;
@@ -54,6 +56,9 @@ import static java.lang.Math.sin;
  * @author Sylvain PALOMINOS
  */
 public class TextRenderer implements RendererRaster, RendererVector, CustomConfigurationPanel {
+
+    /** Object for the translation*/
+    private static final I18n i18n = I18nFactory.getI18n(TextRenderer.class);
 
     @Override
     public void drawGE(Graphics2D graphics2D, GraphicalElement ge){
@@ -141,7 +146,7 @@ public class TextRenderer implements RendererRaster, RendererVector, CustomConfi
             if(ca.getName().equals(TextElement.sText))
                 textCA = (StringCA)ca;
         //Create the list of component composing the ConfigurationAttribute representation.
-        name = new JLabel(textCA.getName());
+        name = new JLabel(i18n.tr(textCA.getName()));
         uid.addComponent(name, textCA, 0, 0, 1, 1);
 
         component = new JScrollPane(uic.getCAManager().getRenderer(textCA).createJComponentFromCA(textCA));
@@ -153,7 +158,7 @@ public class TextRenderer implements RendererRaster, RendererVector, CustomConfi
             if(ca.getName().equals(TextElement.sFont))
                 fontCA = (SourceListCA)ca;
         //Create the list of component composing the ConfigurationAttribute representation.
-        name = new JLabel(fontCA.getName());
+        name = new JLabel(i18n.tr(fontCA.getName()));
         uid.addComponent(name, fontCA, 0, 4, 1, 1);
 
         component = uic.getCAManager().getRenderer(fontCA).createJComponentFromCA(fontCA);
@@ -165,7 +170,7 @@ public class TextRenderer implements RendererRaster, RendererVector, CustomConfi
             if(ca.getName().equals(TextElement.sFontSize))
                 fontSizeCA = (IntegerCA)ca;
         //Create the list of component composing the ConfigurationAttribute representation.
-        name = new JLabel(fontSizeCA.getName());
+        name = new JLabel(i18n.tr(fontSizeCA.getName()));
         uid.addComponent(name, fontSizeCA, 0, 5, 2, 1);
 
         component = uic.getCAManager().getRenderer(fontSizeCA).createJComponentFromCA(fontSizeCA);
@@ -177,7 +182,7 @@ public class TextRenderer implements RendererRaster, RendererVector, CustomConfi
             if(ca.getName().equals(TextElement.sStyle))
                 styleCA = (SourceListCA) ca;
         //Create the list of component composing the ConfigurationAttribute representation.
-        name = new JLabel(styleCA.getName());
+        name = new JLabel(i18n.tr(styleCA.getName()));
         uid.addComponent(name, styleCA, 0, 6, 2, 1);
 
         component = uic.getCAManager().getRenderer(styleCA).createJComponentFromCA(styleCA);
@@ -190,7 +195,7 @@ public class TextRenderer implements RendererRaster, RendererVector, CustomConfi
             if(ca.getName().equals(TextElement.sAlignment))
                 alignmentCA = (SourceListCA)ca;
         //Create the list of component composing the ConfigurationAttribute representation.
-        name = new JLabel(alignmentCA.getName());
+        name = new JLabel(i18n.tr(alignmentCA.getName()));
         uid.addComponent(name, alignmentCA, 0, 7, 2, 1);
 
         component = uic.getCAManager().getRenderer(alignmentCA).createJComponentFromCA(alignmentCA);
@@ -202,11 +207,11 @@ public class TextRenderer implements RendererRaster, RendererVector, CustomConfi
             if(ca.getName().equals(TextElement.sTextColor))
                 textColorCA = (ColorCA)ca;
         //Create the list of component composing the ConfigurationAttribute representation.
-        name = new JLabel(textColorCA.getName());
+        name = new JLabel(i18n.tr(textColorCA.getName()));
         uid.addComponent(name, textColorCA, 0, 8, 3, 1);
 
         component = uic.getCAManager().getRenderer(textColorCA).createJComponentFromCA(textColorCA);
-        uid.addComponent(component, textColorCA, 3, 8, 1, 1);
+        uid.addComponent(component, textColorCA, 2, 8, 1, 1);
 
         //Find the Font ConfigurationAttribute
         ColorCA backgroundColorCA = null;
@@ -214,11 +219,11 @@ public class TextRenderer implements RendererRaster, RendererVector, CustomConfi
             if(ca.getName().equals(TextElement.sBackColor))
                 backgroundColorCA = (ColorCA)ca;
         //Create the list of component composing the ConfigurationAttribute representation.
-        name = new JLabel(backgroundColorCA.getName());
+        name = new JLabel(i18n.tr(backgroundColorCA.getName()));
         uid.addComponent(name, backgroundColorCA, 0, 9, 3, 1);
 
         component = uic.getCAManager().getRenderer(backgroundColorCA).createJComponentFromCA(backgroundColorCA);
-        uid.addComponent(component, backgroundColorCA, 3, 9, 1, 1);
+        uid.addComponent(component, backgroundColorCA, 2, 9, 1, 1);
 
         //Find the Font ConfigurationAttribute
         IntegerCA alphaCA = null;
@@ -226,11 +231,11 @@ public class TextRenderer implements RendererRaster, RendererVector, CustomConfi
             if(ca.getName().equals(TextElement.sAlpha))
                 alphaCA = (IntegerCA)ca;
         //Create the list of component composing the ConfigurationAttribute representation.
-        name = new JLabel(alphaCA.getName());
+        name = new JLabel(i18n.tr(alphaCA.getName()));
         uid.addComponent(name, alphaCA, 0, 10, 1, 1);
 
         component = uic.getCAManager().getRenderer(alphaCA).createJComponentFromCA(alphaCA);
-        uid.addComponent(component, alphaCA, 1, 10, 1, 1);
+        uid.addComponent(component, alphaCA, 2, 10, 1, 1);
 
         return uid;
     }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
@@ -206,6 +206,16 @@ public class CompositionArea extends JPanel {
         }
         positionJLabel.revalidate();
     }
+
+    /**
+     * Sets the unit used for the scales according to the given on.
+     * @param unit The new unit of the scales
+     */
+    public void setInchOrCom(Document.Unit unit){
+        if((this.unit == UNIT_INCH && unit!= Document.Unit.IN) || (this.unit == UNIT_MM && unit!= Document.Unit.MM)){
+            this.toggleInchOrCm();
+        }
+    }
     
     /**
      * Adds a CompositionPanel. Should be call only once for each GraphicalElement.
@@ -250,6 +260,11 @@ public class CompositionArea extends JPanel {
         this.dimension =dimension;
         this.layeredPane.setPreferredSize(this.dimension);
         document.setBounds((layeredPane.getWidth() - dimension.width) / 2, (layeredPane.getHeight() - dimension.height) / 2, dimension.width, dimension.height);
+
+        horizontalPositionScale.setDocumentOriginPosition((layeredPane.getWidth() - dimension.width) / 2,
+                document.getWidth());
+        verticalPositionScale.setDocumentOriginPosition((layeredPane.getHeight() - dimension.height) / 2,
+                document.getHeight());
     }
 
     /**

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
@@ -74,6 +74,8 @@ public class CompositionArea extends JPanel {
     /** JLabel displaying the mouse position */
     private JLabel positionJLabel;
 
+    /** Fixed size of the PositionScale used as header view in the JScrollPane */
+    private final static int POSITIONSCALE_DIMENSION = 30;
     /** The vertical PositionScale */
     private PositionScale verticalPositionScale;
 
@@ -91,8 +93,6 @@ public class CompositionArea extends JPanel {
 
     /** Corner button of the ScrollPane to change the dimension unit */
     private JButton inchOrCm;
-
-    private static int SCALE_SIZE = 30;
 
     /**
      * Main constructor.
@@ -114,11 +114,11 @@ public class CompositionArea extends JPanel {
 
         //Sets the ScrollPane that will contain the layeredPane and sets its header view.
         scrollPane = new JScrollPane(body, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
-        verticalPositionScale = new PositionScale(PositionScale.VERTICAL, SCALE_SIZE);
-        horizontalPositionScale = new PositionScale(PositionScale.HORIZONTAL, SCALE_SIZE);
+        verticalPositionScale = new PositionScale(PositionScale.VERTICAL, POSITIONSCALE_DIMENSION);
+        horizontalPositionScale = new PositionScale(PositionScale.HORIZONTAL, POSITIONSCALE_DIMENSION);
         inchOrCm = new JButton("in");
         inchOrCm.setMargin(new Insets(0, 0, 0, 0));
-        inchOrCm.setFont(new Font("Arial", Font.PLAIN, SCALE_SIZE/4));
+        inchOrCm.setFont(new Font("Arial", Font.PLAIN, POSITIONSCALE_DIMENSION/4));
         inchOrCm.addActionListener(EventHandler.create(ActionListener.class, this, "toggleInchOrCm"));
         scrollPane.setRowHeaderView(verticalPositionScale);
         scrollPane.setColumnHeaderView(horizontalPositionScale);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/CompositionArea.java
@@ -30,6 +30,8 @@ import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GEProperties;
 import org.orbisgis.mapcomposer.view.utils.CompositionAreaOverlay;
 import org.orbisgis.mapcomposer.view.utils.CompositionJPanel;
 import org.orbisgis.mapcomposer.view.utils.PositionScale;
+import org.xnap.commons.i18n.I18n;
+import org.xnap.commons.i18n.I18nFactory;
 
 import java.awt.*;
 import java.awt.event.*;
@@ -94,6 +96,9 @@ public class CompositionArea extends JPanel {
     /** Corner button of the ScrollPane to change the dimension unit */
     private JButton inchOrCm;
 
+    /** Translation*/
+    private static final I18n i18n = I18nFactory.getI18n(CompositionArea.class);
+
     /**
      * Main constructor.
      */
@@ -116,7 +121,7 @@ public class CompositionArea extends JPanel {
         scrollPane = new JScrollPane(body, JScrollPane.VERTICAL_SCROLLBAR_ALWAYS, JScrollPane.HORIZONTAL_SCROLLBAR_ALWAYS);
         verticalPositionScale = new PositionScale(PositionScale.VERTICAL, POSITIONSCALE_DIMENSION);
         horizontalPositionScale = new PositionScale(PositionScale.HORIZONTAL, POSITIONSCALE_DIMENSION);
-        inchOrCm = new JButton("in");
+        inchOrCm = new JButton(i18n.tr("in"));
         inchOrCm.setMargin(new Insets(0, 0, 0, 0));
         inchOrCm.setFont(new Font("Arial", Font.PLAIN, POSITIONSCALE_DIMENSION/4));
         inchOrCm.addActionListener(EventHandler.create(ActionListener.class, this, "toggleInchOrCm"));
@@ -194,13 +199,13 @@ public class CompositionArea extends JPanel {
     public void toggleInchOrCm(){
         if(unit == UNIT_INCH){
             unit = UNIT_MM;
-            inchOrCm.setText("mm");
+            inchOrCm.setText(i18n.tr("mm"));
             verticalPositionScale.setUnit(UNIT_MM);
             horizontalPositionScale.setUnit(UNIT_MM);
         }
         else if(unit == UNIT_MM){
             unit = UNIT_INCH;
-            inchOrCm.setText("in");
+            inchOrCm.setText(i18n.tr("in"));
             verticalPositionScale.setUnit(UNIT_INCH);
             horizontalPositionScale.setUnit(UNIT_INCH);
         }
@@ -401,19 +406,19 @@ public class CompositionArea extends JPanel {
             //Calculate the position in inch or mm of the mouse for the positionLabel
             float x = (float)(position.x-document.getLocationOnScreen().x) / PositionScale.DPI;
             float y = (float)(position.y-document.getLocationOnScreen().y) / PositionScale.DPI;
-            String unitName = "px";
+            String unitName = i18n.tr("px");
             DecimalFormat df = new DecimalFormat();
             if(unit == UNIT_INCH) {
                 df.setMaximumFractionDigits(2);
-                unitName = "in";
+                unitName = i18n.tr("in");
             }
             else if(unit == UNIT_MM) {
                 df.setMaximumFractionDigits(0);
                 x *= 25.4;
                 y *= 25.4;
-                unitName = "mm";
+                unitName = i18n.tr("mm");
             }
-            positionJLabel.setText("x : " + df.format(x) + unitName + " , y : " + df.format(y) + unitName);
+            positionJLabel.setText(i18n.tr("x : " + df.format(x) + unitName + " , y : " + df.format(y) + unitName));
         }
     }
 
@@ -464,9 +469,9 @@ public class CompositionArea extends JPanel {
     public void configure(int unit){
         this.unit = unit;
         if(unit == UNIT_MM)
-            inchOrCm.setText("mm");
+            inchOrCm.setText(i18n.tr("mm"));
         else
-            inchOrCm.setText("in");
+            inchOrCm.setText(i18n.tr("in"));
         verticalPositionScale.setUnit(unit);
         horizontalPositionScale.setUnit(unit);
     }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -348,16 +348,16 @@ public class MainWindow extends JFrame implements EditableElement {
 
         //Sets the spinners tool bar.
         spinnerX = createSpinner("X", 0, Integer.MIN_VALUE, Integer.MAX_VALUE);
-        addToolbarSpinner("spinnerX", new JLabel(I18n.marktr("X")), spinnerX, stationLocation, 0, 1, 0, 1);
+        addToolbarSpinner("spinnerX", new JLabel(i18n.tr("X")), spinnerX, stationLocation, 0, 1, 0, 1);
 
         spinnerY = createSpinner("Y", 0, Integer.MIN_VALUE, Integer.MAX_VALUE);
-        addToolbarSpinner("spinnerY", new JLabel(I18n.marktr("Y")), spinnerY, stationLocation, 0, 1, 0, 2);
+        addToolbarSpinner("spinnerY", new JLabel(i18n.tr("Y")), spinnerY, stationLocation, 0, 1, 0, 2);
 
         spinnerW = createSpinner("WIDTH", 0, Integer.MIN_VALUE, Integer.MAX_VALUE);
-        addToolbarSpinner("spinnerWidth", new JLabel(I18n.marktr("WIDTH")), spinnerW, stationLocation, 0, 1, 0, 3);
+        addToolbarSpinner("spinnerWidth", new JLabel(i18n.tr("WIDTH")), spinnerW, stationLocation, 0, 1, 0, 3);
 
         spinnerH = createSpinner("HEIGHT", 0, Integer.MIN_VALUE, Integer.MAX_VALUE);
-        addToolbarSpinner("spinnerHeight", new JLabel(I18n.marktr("HEIGHT")), spinnerH, stationLocation, 0, 1, 0, 4);
+        addToolbarSpinner("spinnerHeight", new JLabel(i18n.tr("HEIGHT")), spinnerH, stationLocation, 0, 1, 0, 4);
 
         spinnerR = createSpinner("ROTATION", 0, -360, 360);
         addToolbarSpinner("spinnerRotation", new JLabel(MapComposerIcon.getIcon("rotation")), spinnerR,
@@ -562,6 +562,6 @@ public class MainWindow extends JFrame implements EditableElement {
                 documentName = ((Document)ge).getName();
             }
         }
-        return "MapComposer document - "+documentName;
+        return i18n.tr("MapComposer document - "+documentName);
     }
 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -34,14 +34,19 @@ import bibliothek.gui.dock.themes.border.BorderModifier;
 import bibliothek.gui.dock.toolbar.CToolbarContentArea;
 import bibliothek.gui.dock.toolbar.CToolbarItem;
 import bibliothek.gui.dock.toolbar.location.CToolbarAreaLocation;
+
+import org.orbisgis.commons.progress.ProgressMonitor;
 import org.orbisgis.corejdbc.DataManager;
 import org.orbisgis.mapcomposer.Activator;
 import org.orbisgis.mapcomposer.controller.MainController;
+import org.orbisgis.mapcomposer.model.graphicalelement.element.Document;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement.Property;
 import org.orbisgis.mapcomposer.view.utils.MapComposerIcon;
 import org.orbisgis.mapeditorapi.MapEditorExtension;
 import org.orbisgis.sif.UIFactory;
+import org.orbisgis.sif.edition.EditableElement;
+import org.orbisgis.sif.edition.EditableElementException;
 import org.orbisgis.wkguiapi.ViewWorkspace;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -64,8 +69,6 @@ import java.awt.FlowLayout;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.beans.EventHandler;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -82,7 +85,7 @@ import java.util.Hashtable;
  * @author Sylvain PALOMINOS
  */
 
-public class MainWindow extends JFrame {
+public class MainWindow extends JFrame implements EditableElement {
 
     //String used to define the toolbars actions
     public static final String NEW_COMPOSER = "NEW_COMPOSER";
@@ -130,6 +133,9 @@ public class MainWindow extends JFrame {
 
     /** Object for the translation*/
     private static final I18n i18n = I18nFactory.getI18n(MainWindow.class);
+
+    /** True if the document has been modified and not saved, false otherwise */
+    private boolean modified;
 
     private CControl control;
 
@@ -474,5 +480,60 @@ public class MainWindow extends JFrame {
 
     public void setConfigurationAdmin(ConfigurationAdmin configurationAdmin) {
         this.configurationAdmin = configurationAdmin;
+    }
+
+    @Override
+    public String getId() {
+        return null;
+    }
+
+    @Override
+    public boolean isModified() {
+        return modified;
+    }
+
+    @Override
+    public void setModified(boolean modified) {
+        this.modified = modified;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return this.isVisible();
+    }
+
+    @Override
+    public String getTypeId() {
+        return null;
+    }
+
+    @Override
+    public void open(ProgressMonitor progressMonitor) throws UnsupportedOperationException, EditableElementException {
+        mainController.loadDocument();
+    }
+
+    @Override
+    public void save() throws UnsupportedOperationException, EditableElementException {
+        mainController.saveDocument();
+    }
+
+    @Override
+    public void close(ProgressMonitor progressMonitor) throws UnsupportedOperationException, EditableElementException {
+    }
+
+    @Override
+    public Object getObject() throws UnsupportedOperationException {
+        return null;
+    }
+
+    @Override
+    public String toString(){
+        String documentName = "";
+        for(GraphicalElement ge : mainController.getGEList()){
+            if(ge instanceof Document){
+                documentName = ((Document)ge).getName();
+            }
+        }
+        return "MapComposer document - "+documentName;
     }
 }

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -40,6 +40,7 @@ import org.orbisgis.mapcomposer.controller.MainController;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement;
 import org.orbisgis.mapcomposer.model.graphicalelement.interfaces.GraphicalElement.Property;
 import org.orbisgis.mapcomposer.view.utils.MapComposerIcon;
+import org.orbisgis.mapeditorapi.MapEditorExtension;
 import org.orbisgis.sif.UIFactory;
 import org.orbisgis.wkguiapi.ViewWorkspace;
 import org.osgi.service.cm.Configuration;
@@ -148,12 +149,6 @@ public class MainWindow extends JFrame {
         this.setSize(1024, 768);
         this.setIconImage(MapComposerIcon.getIcon("map_composer").getImage());
         this.control = new CControl(this);
-        this.addWindowListener(new WindowAdapter() {
-            @Override
-            public void windowClosing(WindowEvent we) {
-                //onCloseWindow();
-            }
-        });
     }
 
     /**
@@ -428,6 +423,10 @@ public class MainWindow extends JFrame {
 
     public void setViewWorkspace(ViewWorkspace viewWorkspace) {
         this.mainController.setViewWorkspace(viewWorkspace);
+    }
+
+    public void setMapEditorExtension(MapEditorExtension mapEditorExtension) {
+        this.mainController.setMapEditorExtension(mapEditorExtension);
     }
 
     public void close(){

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/ui/MainWindow.java
@@ -289,34 +289,62 @@ public class MainWindow extends JFrame implements EditableElement {
 
         CToolbarAreaLocation stationLocation = area.getNorthToolbar().getStationLocation();
 
-        addCToolbarCItem(NEW_COMPOSER, i18n.tr("Create a new document"), "new_composer", mainController.getUIController(), "createDocument", KeyStroke.getKeyStroke("control N"), stationLocation, 0, 0, 0, 0);
-        addCToolbarCItem(CONFIGURATION, i18n.tr("Show the document configuration dialog"), "configuration", mainController.getUIController(), "showDocProperties", KeyStroke.getKeyStroke("control D"), stationLocation, 0, 0, 0, 1);
-        addCToolbarCItem(SAVE, i18n.tr("Save the document"), "save", mainController, "saveDocument", KeyStroke.getKeyStroke("control S"), stationLocation, 0, 0, 0, 2);
-        addCToolbarCItem(LOAD, i18n.tr("Open a document"), "open", mainController, "loadDocument", KeyStroke.getKeyStroke("control O"), stationLocation, 0, 0, 0, 3);
-        addCToolbarCItem(EXPORT_COMPOSER, i18n.tr("Export the document"), "export_composer", mainController, "export", KeyStroke.getKeyStroke("control E"), stationLocation, 0, 0, 0, 4);
-        addCToolbarCItem(ADD_MAP, i18n.tr("Add a map element"), "add_map", mainController.getUIController(), "createMap", KeyStroke.getKeyStroke("alt M"), stationLocation, 0, 0, 1, 0);
-        addCToolbarCItem(ADD_TEXT, i18n.tr("Add a text element"), "add_text", mainController.getUIController(), "createText", KeyStroke.getKeyStroke("alt T"), stationLocation, 0, 0, 1, 1);
-        addCToolbarCItem(ADD_LEGEND, i18n.tr("Add a legend element"), "add_legend", mainController.getUIController(), "createLegend", KeyStroke.getKeyStroke("alt L"), stationLocation, 0, 0, 1, 2);
-        addCToolbarCItem(ADD_ORIENTATION, i18n.tr("Add an orientation element"), "compass", mainController.getUIController(), "createOrientation", KeyStroke.getKeyStroke("alt O"), stationLocation, 0, 0, 1, 3);
-        addCToolbarCItem(ADD_SCALE, i18n.tr("Add a scale element"), "add_scale", mainController.getUIController(), "createScale", KeyStroke.getKeyStroke("alt S"), stationLocation, 0, 0, 1, 4);
-        addCToolbarCItem(ADD_PICTURE, i18n.tr("Add a picture element"), "add_picture", mainController.getUIController(), "createPicture", KeyStroke.getKeyStroke("alt I"), stationLocation, 0, 0, 1, 5);
-        addCToolbarCItem(DRAW_CIRCLE, i18n.tr("Add a circle element"), "draw_circle", mainController.getUIController(), "createCircle", KeyStroke.getKeyStroke("alt C"), stationLocation, 0, 0, 2, 0);
-        addCToolbarCItem(DRAW_POLYGON, i18n.tr("Add a polygon element"), "draw_polygon", mainController.getUIController(), "createPolygon", KeyStroke.getKeyStroke("alt Y"), stationLocation, 0, 0, 2, 1);
-        addCToolbarCItem(MOVE_BACK, i18n.tr("Move to the back"), "move_back", mainController.getUIController(), "moveBack", KeyStroke.getKeyStroke("alt PAGE_DOWN"), stationLocation, 0, 0, 3, 0);
-        addCToolbarCItem(MOVE_DOWN, i18n.tr("Move down"), "move_down", mainController.getUIController(), "moveDown", KeyStroke.getKeyStroke("alt DOWN"), stationLocation, 0, 0, 3, 1);
-        addCToolbarCItem(MOVE_ON, i18n.tr("Move on"), "move_on", mainController.getUIController(), "moveOn", KeyStroke.getKeyStroke("alt UP"), stationLocation, 0, 0, 3, 2);
-        addCToolbarCItem(MOVE_FRONT, i18n.tr("Move to the front"), "move_front", mainController.getUIController(), "moveFront", KeyStroke.getKeyStroke("alt PAGE_UP"), stationLocation, 0, 0, 3, 3);
-        addCToolbarCItem(ALIGN_TO_LEFT, i18n.tr("Align to the left"), "align_to_left", mainController.getUIController(), "alignToLeft", KeyStroke.getKeyStroke("alt NUMPAD4"), stationLocation, 0, 0, 4, 0);
-        addCToolbarCItem(ALIGN_TO_CENTER, i18n.tr("Align to the center"), "align_to_center", mainController.getUIController(), "alignToCenter", null, stationLocation, 0, 0, 4, 1);
-        addCToolbarCItem(ALIGN_TO_RIGHT, i18n.tr("Align to the right"), "align_to_right", mainController.getUIController(), "alignToRight", KeyStroke.getKeyStroke("alt NUMPAD6"), stationLocation, 0, 0, 4, 2);
-        addCToolbarCItem(ALIGN_TO_BOTTOM, i18n.tr("Align to the bottom"), "align_to_bottom", mainController.getUIController(), "alignToBottom", KeyStroke.getKeyStroke("alt NUMPAD2"), stationLocation, 0, 0, 4, 3);
-        addCToolbarCItem(ALIGN_TO_MIDDLE, i18n.tr("Align to the middle"), "align_to_middle", mainController.getUIController(), "alignToMiddle", null, stationLocation, 0, 0, 4, 4);
-        addCToolbarCItem(ALIGN_TO_TOP, i18n.tr("Align to the top"), "align_to_top", mainController.getUIController(), "alignToTop", KeyStroke.getKeyStroke("alt NUMPAD8"), stationLocation, 0, 0, 4, 5);
-        addCToolbarCItem(PROPERTIES, i18n.tr("Show selected elements properties"), "properties", mainController.getUIController(), "showSelectedGEProperties", KeyStroke.getKeyStroke("control P"), stationLocation, 0, 0, 5, 0);
-        addCToolbarCItem(DELETE, i18n.tr("Delete selected elements"), "delete", mainController, "removeSelectedGE", KeyStroke.getKeyStroke("DELETE"), stationLocation, 0, 0, 5, 1);
-        addCToolbarCItem(REFRESH, i18n.tr("Redraw selected elements"), "refresh", mainController.getCompositionAreaController(), "refreshSelectedGE", KeyStroke.getKeyStroke("control R"), stationLocation, 0, 0, 5, 2);
-        addCToolbarCItem(UNDO, i18n.tr("Undo the last action"), "edit_undo", mainController, "undo", KeyStroke.getKeyStroke("control Z"), stationLocation, 0, 0, 5, 3);
-        addCToolbarCItem(REDO, i18n.tr("Redo the last action"), "edit_redo", mainController, "redo", KeyStroke.getKeyStroke("control shift Z"), stationLocation, 0, 0, 5, 4);
+        addCToolbarCItem(NEW_COMPOSER, i18n.tr("Create a new document"), "new_composer", mainController.getUIController(),
+                "createDocument", KeyStroke.getKeyStroke("control N"), stationLocation, 0, 0, 0, 0);
+        addCToolbarCItem(CONFIGURATION, i18n.tr("Show the document configuration dialog"), "configuration", mainController.getUIController(),
+                "showDocProperties", KeyStroke.getKeyStroke("control D"), stationLocation, 0, 0, 0, 1);
+        addCToolbarCItem(SAVE, i18n.tr("Save the document"), "save", mainController,
+                "saveDocument", KeyStroke.getKeyStroke("control S"), stationLocation, 0, 0, 0, 2);
+        addCToolbarCItem(LOAD, i18n.tr("Open a document"), "open", mainController.getUIController(),
+                "openDocument", KeyStroke.getKeyStroke("control O"), stationLocation, 0, 0, 0, 3);
+        addCToolbarCItem(EXPORT_COMPOSER, i18n.tr("Export the document"), "export_composer", mainController,
+                "export", KeyStroke.getKeyStroke("control E"), stationLocation, 0, 0, 0, 4);
+        addCToolbarCItem(ADD_MAP, i18n.tr("Add a map element"), "add_map", mainController.getUIController(),
+                "createMap", KeyStroke.getKeyStroke("alt M"), stationLocation, 0, 0, 1, 0);
+        addCToolbarCItem(ADD_TEXT, i18n.tr("Add a text element"), "add_text", mainController.getUIController(),
+                "createText", KeyStroke.getKeyStroke("alt T"), stationLocation, 0, 0, 1, 1);
+        addCToolbarCItem(ADD_LEGEND, i18n.tr("Add a legend element"), "add_legend", mainController.getUIController(),
+                "createLegend", KeyStroke.getKeyStroke("alt L"), stationLocation, 0, 0, 1, 2);
+        addCToolbarCItem(ADD_ORIENTATION, i18n.tr("Add an orientation element"), "compass", mainController.getUIController(),
+                "createOrientation", KeyStroke.getKeyStroke("alt O"), stationLocation, 0, 0, 1, 3);
+        addCToolbarCItem(ADD_SCALE, i18n.tr("Add a scale element"), "add_scale", mainController.getUIController(),
+                "createScale", KeyStroke.getKeyStroke("alt S"), stationLocation, 0, 0, 1, 4);
+        addCToolbarCItem(ADD_PICTURE, i18n.tr("Add a picture element"), "add_picture", mainController.getUIController(),
+                "createPicture", KeyStroke.getKeyStroke("alt I"), stationLocation, 0, 0, 1, 5);
+        addCToolbarCItem(DRAW_CIRCLE, i18n.tr("Add a circle element"), "draw_circle", mainController.getUIController(),
+                "createCircle", KeyStroke.getKeyStroke("alt C"), stationLocation, 0, 0, 2, 0);
+        addCToolbarCItem(DRAW_POLYGON, i18n.tr("Add a polygon element"), "draw_polygon", mainController.getUIController(),
+                "createPolygon", KeyStroke.getKeyStroke("alt Y"), stationLocation, 0, 0, 2, 1);
+        addCToolbarCItem(MOVE_BACK, i18n.tr("Move to the back"), "move_back", mainController.getUIController(),
+                "moveBack", KeyStroke.getKeyStroke("alt PAGE_DOWN"), stationLocation, 0, 0, 3, 0);
+        addCToolbarCItem(MOVE_DOWN, i18n.tr("Move down"), "move_down", mainController.getUIController(),
+                "moveDown", KeyStroke.getKeyStroke("alt DOWN"), stationLocation, 0, 0, 3, 1);
+        addCToolbarCItem(MOVE_ON, i18n.tr("Move on"), "move_on", mainController.getUIController(),
+                "moveOn", KeyStroke.getKeyStroke("alt UP"), stationLocation, 0, 0, 3, 2);
+        addCToolbarCItem(MOVE_FRONT, i18n.tr("Move to the front"), "move_front", mainController.getUIController(),
+                "moveFront", KeyStroke.getKeyStroke("alt PAGE_UP"), stationLocation, 0, 0, 3, 3);
+        addCToolbarCItem(ALIGN_TO_LEFT, i18n.tr("Align to the left"), "align_to_left", mainController.getUIController(),
+                "alignToLeft", KeyStroke.getKeyStroke("alt NUMPAD4"), stationLocation, 0, 0, 4, 0);
+        addCToolbarCItem(ALIGN_TO_CENTER, i18n.tr("Align to the center"), "align_to_center", mainController.getUIController(),
+                "alignToCenter", null, stationLocation, 0, 0, 4, 1);
+        addCToolbarCItem(ALIGN_TO_RIGHT, i18n.tr("Align to the right"), "align_to_right", mainController.getUIController(),
+                "alignToRight", KeyStroke.getKeyStroke("alt NUMPAD6"), stationLocation, 0, 0, 4, 2);
+        addCToolbarCItem(ALIGN_TO_BOTTOM, i18n.tr("Align to the bottom"), "align_to_bottom", mainController.getUIController(),
+                "alignToBottom", KeyStroke.getKeyStroke("alt NUMPAD2"), stationLocation, 0, 0, 4, 3);
+        addCToolbarCItem(ALIGN_TO_MIDDLE, i18n.tr("Align to the middle"), "align_to_middle", mainController.getUIController(),
+                "alignToMiddle", null, stationLocation, 0, 0, 4, 4);
+        addCToolbarCItem(ALIGN_TO_TOP, i18n.tr("Align to the top"), "align_to_top", mainController.getUIController(),
+                "alignToTop", KeyStroke.getKeyStroke("alt NUMPAD8"), stationLocation, 0, 0, 4, 5);
+        addCToolbarCItem(PROPERTIES, i18n.tr("Show selected elements properties"), "properties", mainController.getUIController(),
+                "showSelectedGEProperties", KeyStroke.getKeyStroke("control P"), stationLocation, 0, 0, 5, 0);
+        addCToolbarCItem(DELETE, i18n.tr("Delete selected elements"), "delete", mainController,
+                "removeSelectedGE", KeyStroke.getKeyStroke("DELETE"), stationLocation, 0, 0, 5, 1);
+        addCToolbarCItem(REFRESH, i18n.tr("Redraw selected elements"), "refresh", mainController.getCompositionAreaController(),
+                "refreshSelectedGE", KeyStroke.getKeyStroke("control R"), stationLocation, 0, 0, 5, 2);
+        addCToolbarCItem(UNDO, i18n.tr("Undo the last action"), "edit_undo", mainController,
+                "undo", KeyStroke.getKeyStroke("control Z"), stationLocation, 0, 0, 5, 3);
+        addCToolbarCItem(REDO, i18n.tr("Redo the last action"), "edit_redo", mainController,
+                "redo", KeyStroke.getKeyStroke("control shift Z"), stationLocation, 0, 0, 5, 4);
 
         //Sets the spinners tool bar.
         spinnerX = createSpinner("X", 0, Integer.MIN_VALUE, Integer.MAX_VALUE);

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/PositionScale.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/PositionScale.java
@@ -91,9 +91,7 @@ public class PositionScale extends JComponent {
         //Gets the position od the document start and end on the scale
         int startDocumentPos = (documentOriginPosition-scrollValue);
         int endDocumentPos = (documentOriginPosition+documentSize-scrollValue);
-
         int unitPosition = startDocumentPos%units;
-
         //Gets the scale start position, length and width
         int xRect = this.getX();
         int yRect = this.getY();

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java
@@ -39,6 +39,7 @@ import java.awt.Component;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Stack;
 
 /**
  * This class is the UIPanel of the export configuration dialog.
@@ -67,19 +68,19 @@ public class UIDialogExportConfiguration implements UIPanel {
     /** GEManager containing all the rendering methods */
     private GEManager geManager;
 
-    /** List of GraphicalElements to export */
-    private List<GraphicalElement> listGEToExport;
+    /** Stack of GraphicalElements to export */
+    private Stack<GraphicalElement> stackGEToExport;
 
     /**
      * Main constructor
-     * @param listGEToExport List of GraphicalElement to export.
+     * @param stackGEToExport Stack of GraphicalElement to export.
      * @param geManager GeManager containing the rendering methods.
      */
-    public UIDialogExportConfiguration(List<GraphicalElement> listGEToExport, GEManager geManager) {
+    public UIDialogExportConfiguration(Stack<GraphicalElement> stackGEToExport, GEManager geManager) {
         this.panel = new JPanel();
         this.exportThreadList = new ArrayList<>();
         this.geManager = geManager;
-        this.listGEToExport = listGEToExport;
+        this.stackGEToExport = stackGEToExport;
 
         //Sets and add the JTabbedPane
         tabbedPane = new JTabbedPane();
@@ -97,7 +98,7 @@ public class UIDialogExportConfiguration implements UIPanel {
     public void addExportThread(ExportThread exportThread){
         exportThreadList.add(exportThread);
         exportThread.setGEManager(geManager);
-        tabbedPane.addTab(exportThread.getName(), null, exportThread.constructExportPanel(listGEToExport), exportThread.getDescription());
+        tabbedPane.addTab(exportThread.getName(), null, exportThread.constructExportPanel(stackGEToExport), exportThread.getDescription());
     }
 
     @Override

--- a/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java
+++ b/MapComposer/src/main/java/org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java
@@ -98,7 +98,7 @@ public class UIDialogProperties implements UIPanel {
         for(int i=0; i<caList.size(); i++){
             if(caList.get(i) instanceof RefreshCA)
                 ((RefreshCA)caList.get(i)).refresh(mainController);
-            JLabel name = new JLabel(caList.get(i).getName());
+            JLabel name = new JLabel(i18n.tr(caList.get(i).getName()));
             JComponent component = mainController.getCAManager().getRenderer(caList.get(i)).createJComponentFromCA(caList.get(i));
             if(enableLock) {
                 EnableCheckBox checkBox = new EnableCheckBox(caList.get(i));

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/ar.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/ar.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Arabic (http://www.transifex.com/projects/p/orbisgis/language/ar/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: ar\n"
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/br.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/br.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Breton (http://www.transifex.com/projects/p/orbisgis/language/br/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: br\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/de_DE.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/de_DE.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: German (Germany) (http://www.transifex.com/projects/p/orbisgis/language/de_DE/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: de_DE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/en_US.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/en_US.po
@@ -3,13 +3,14 @@
 # This file is distributed under the same license as the PACKAGE package.
 # 
 # Translators:
+# Gwendall Petit <gwendall.petit@ec-nantes.fr>, 2015
 msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: English (United States) (http://www.transifex.com/projects/p/orbisgis/language/en_US/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,261 +18,498 @@ msgstr ""
 "Language: en_US\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
-msgstr ""
+msgstr "Orientation"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
+msgstr "Format"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
-msgstr ""
+msgstr "Name"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
+msgstr "Document title"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
-msgid "Path"
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
 msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
+msgid "Path"
+msgstr "Path"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:63
 msgid "x"
-msgstr ""
+msgstr "x"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:66
 msgid "y"
-msgstr ""
+msgstr "y"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:69
 msgid "Rotation"
-msgstr ""
+msgstr "Rotation"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:72
 msgid "Height"
-msgstr ""
+msgstr "Height"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr "Width"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:73
 msgid "Text color"
-msgstr ""
+msgstr "Text color"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:75
 msgid "Background color"
-msgstr ""
+msgstr "Background color"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:77
 msgid "Alignment"
-msgstr ""
+msgstr "Alignment"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:79
 msgid "Style"
-msgstr ""
+msgstr "Style"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:81
 msgid "Alpha"
-msgstr ""
+msgstr "Alpha"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:83
 msgid "Font"
-msgstr ""
+msgstr "Font"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:85
 msgid "Font size"
-msgstr ""
+msgstr "Font size"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
+msgstr "Some text"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
-msgstr ""
+msgstr "Link to MapImage"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
+msgstr "OWS-Context path"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
+msgstr "Configuration"
+
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
+msgstr "Select source"
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
+msgstr "Align to the center"
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
+msgstr "Align to the middle"
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
-msgstr ""
+msgstr "Export document"

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/es.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/es.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:52+0000\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
 "Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Spanish (http://www.transifex.com/projects/p/orbisgis/language/es/)\n"
 "MIME-Version: 1.0\n"
@@ -18,24 +18,67 @@ msgstr ""
 "Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr "Orientación"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr "Formato"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr "Título del proyecto"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr "Título del proyecto"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr "Ruta"
 
@@ -57,6 +100,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -91,188 +138,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/fa.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/fa.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Persian (http://www.transifex.com/projects/p/orbisgis/language/fa/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: fa\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/fi_FI.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/fi_FI.po
@@ -10,11 +10,11 @@ msgstr ""
 "POT-Creation-Date: 2015-05-26 13:26+0200\n"
 "PO-Revision-Date: 2015-05-26 11:28+0000\n"
 "Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
-"Language-Team: Greek (http://www.transifex.com/projects/p/orbisgis/language/el/)\n"
+"Language-Team: Finnish (Finland) (http://www.transifex.com/projects/p/orbisgis/language/fi_FI/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: el\n"
+"Language: fi_FI\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/fr.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/fr.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:45+0000\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:29+0000\n"
 "Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: French (http://www.transifex.com/projects/p/orbisgis/language/fr/)\n"
 "MIME-Version: 1.0\n"
@@ -18,24 +18,67 @@ msgstr ""
 "Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr "Orientation"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr "Format"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr "Unité"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr "Nom"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr "Titre du document"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr "A4"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr "A3"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr "Personnalisé"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr "mm"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr "in"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr "pixel"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr "Portrait"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr "Paysage"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr "Chemin d'accès"
 
@@ -58,6 +101,10 @@ msgstr "Hauteur"
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
 msgstr "Largeur"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
+msgstr "z"
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
 msgid "Text"
@@ -91,188 +138,378 @@ msgstr "Police"
 msgid "Font size"
 msgstr "Taille de la police"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr "Du texte"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr "Normal"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr "Italique"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr "Gras"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr "Gauche"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr "Centré"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr "Droite"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr "Lier à la carte"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr "Chemin vers le OWS-Context"
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr "Ligne"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr "Vide"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr "Couleur de la forme"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr "Transparence de la forme"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr "Largeur de la bordure"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr "Transparence de la bordure"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr "Couleur de la bordure"
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr "Style de la bordure"
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr "Le fichier de sauvegarde sélectionné - version {0} - n'est pas compatible avec la version actuelle du MapComposer. Versions acceptés : {1} ."
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
-msgstr "Charger un projet"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
+msgstr "Charger un document"
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
-msgstr "Sauvegarder un projet"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
+msgstr "Fichiers de sauvegarde XML"
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr "Sauvegarder un document"
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr "largeur"
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr "hauteur"
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr "Configuration de l'export"
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr "<html>Maintenir <strong>Alt Gr</strong> : redimensionne la représentation de l'élément.<br/>Maintenir <strong>Shift</strong> : redimensionne l'élément tout en conservant le ratio largeur/hauteur.</html>"
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr "Configuration"
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
-msgstr "Valider"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
+msgstr "Palette de couleur :"
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr "Exemple"
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr "Sélectionner la source"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
-msgstr "Créer un nouveau document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
+msgstr "Tous fichiers"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
-msgstr "Afficher les propriétés du projet (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
+msgstr "Parcourir"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
-msgstr "Enregistrer le projet (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
+msgstr "px"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
-msgstr "Ouvrir un projet (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
+msgstr "x :"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
-msgstr "Exporter le projet (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
+msgstr "Créer un nouveau document"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
-msgstr "Ajouter une carte (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
+msgstr "Afficher les propriétés du projet"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
-msgstr "Ajouter du texte (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
+msgstr "Enregistrer le document"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
-msgstr "Ajouter une légende (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
+msgstr "Ouvrir un document"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
-msgstr "Ajouter une orientation (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
+msgstr "Exporter le document"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
-msgstr "Ajouter un échelle (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
+msgstr "Ajouter une carte"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
-msgstr "Ajouter une image (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
+msgstr "Ajouter un texte"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
-msgstr "Ajouter un cercle (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
+msgstr "Ajouter une légende"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
-msgstr "Ajouter un polygone (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
+msgstr "Ajouter une orientation"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
-msgstr "Envoyer vers l'arrière (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
+msgstr "Ajouter un échelle"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
-msgstr "Envoyer vers l'arrière (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
+msgstr "Ajouter une image"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
+msgstr "Ajouter un cercle"
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
+msgstr "Ajouter un polygone"
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
+msgstr "Envoyer à l'arrière"
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr "Envoyer vers l'arrière"
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
 msgstr "Envoyer vers l'avant"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
-msgstr "Envoyer à l'avant (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr "Envoyer à l'avant"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
-msgstr "Aligner à gauche (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr "Aligner à gauche"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr "Aligner au centre"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
-msgstr "Aligner à droite (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
+msgstr "Aligner à droite"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
-msgstr "Aligner en bas (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
+msgstr "Aligner en bas"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr "Aligner au milieu"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
-msgstr "Aligner en haut (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
+msgstr "Aligner en haut"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
-msgstr "Afficher les propriétés des éléments sélectionnés (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
+msgstr "Afficher les propriétés des éléments sélectionnés"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
-msgstr "Supprimer les éléments sélectionnés (Suppr)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
+msgstr "Supprimer les éléments sélectionnés"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
-msgstr "Redessiner les éléments sélectionnés (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
+msgstr "Redessiner les éléments sélectionnés"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
-msgstr "Annuler la dernière action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
+msgstr "Annuler la dernière action"
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
-msgstr "Refaire la dernière action (Ctrl + Maj + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
+msgstr "Refaire la dernière action"
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
-msgstr "Veuillez d'abord créer un nouveau projet ou ouvrir un projet existant."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
+msgstr "X"
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
-msgstr "Vous pouvez maintenant dessiner l'élément graphique "
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
+msgstr "Y"
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
-msgstr "Impossible d'annuler l'action"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
+msgstr "Largeur"
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
-msgstr "Impossible de refaire l'action"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
+msgstr "Hauteur"
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
-msgstr "Cette action n'est pas encore implémentée"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
+msgstr "Document MapComposeur -"
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr "Veuillez d'abord créer un nouveau documet ou ouvrir un existant."
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr "Vous pouvez maintenant dessiner l'élément graphique. Maintenez la touche MAJ pour conserver le ratio largeur/hauteur."
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr "Impossible d'annuler l'action."
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr "Impossible de refaire l'action."
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr "Erreur lors de l'export : la liste des éléments graphiques ne contient aucun document."
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr "vectoriel"
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr "raster"
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr "PDF"
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr "Exporter le document en tant que fichier PDF."
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr "Fichier PDF"
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr "Type d'image :"
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr "png"
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr "jpg"
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr "gif"
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr "Image"
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr "Exporter le document en tant que fichier image."
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr "fichier image"
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr "Nouveau document"
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr "Êtes-vous sûr de vouloir créer un nouveau document ?"
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr "Les changements sauvegardés seront perdus."
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr "Ouvrir un document"
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr "Êtes vous sûr de vouloir ouvrir un document existant ?"
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr "Cette action n'est pas encore implémentée."
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr "Exporter le document"

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/it.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/it.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Italian (http://www.transifex.com/projects/p/orbisgis/language/it/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: it\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/keys.pot
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/keys.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-04-29 15:27+0200\n"
+"POT-Creation-Date: 2015-05-21 09:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,40 +17,56 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:59
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:62
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:73
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:105
-msgid "Portrait"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:106
-msgid "Landscape"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:252
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
 msgid "A4"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:253
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
 msgid "A3"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:254
-msgid "Custom"
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "CUSTOM"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:307
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:308
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:309
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:364
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:365
+msgid "Landscape"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
@@ -144,6 +160,14 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:242
 msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:110
@@ -298,12 +322,12 @@ msgstr ""
 msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:255
-#: org/orbisgis/mapcomposer/controller/GEController.java:262
+#: org/orbisgis/mapcomposer/controller/GEController.java:256
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
 msgid "First create a new document or open an existing one."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:306
+#: org/orbisgis/mapcomposer/controller/GEController.java:310
 msgid ""
 "Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
 "ratio"
@@ -384,6 +408,6 @@ msgstr ""
 msgid "Action not supported yet."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:133
+#: org/orbisgis/mapcomposer/controller/IOController.java:132
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/keys.pot
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/keys.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-21 09:26+0200\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,23 +17,23 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
 msgid "Unit"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:73
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
@@ -46,26 +46,33 @@ msgid "A3"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
-msgid "CUSTOM"
+msgid "Custom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:307
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
 msgid "mm"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:308
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
 msgid "in"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:309
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
 msgid "pixel"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:364
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
 msgid "Portrait"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:365
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
 msgid "Landscape"
 msgstr ""
 
@@ -74,27 +81,27 @@ msgstr ""
 msgid "Path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:60
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:63
 msgid "x"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:63
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:66
 msgid "y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:66
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:69
 msgid "Rotation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:69
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:72
 msgid "Height"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:72
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:81
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
 msgid "z"
 msgstr ""
 
@@ -130,8 +137,32 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
@@ -140,6 +171,38 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
@@ -154,11 +217,11 @@ msgid "Load document"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
 msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:242
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
 msgid "Save document"
 msgstr ""
 
@@ -170,7 +233,7 @@ msgstr ""
 msgid "height"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:110
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
 msgid "Export configuration"
 msgstr ""
 
@@ -189,225 +252,263 @@ msgstr ""
 msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:291
-msgid "Create a new document"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
-msgid "Show the document configuration dialog"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:293
-msgid "Save the document"
+msgid "Create a new document"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
-msgid "Open a document"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:295
-msgid "Export the document"
+msgid "Show the document configuration dialog"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
-msgid "Add a map element"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:297
-msgid "Add a text element"
+msgid "Save the document"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
-msgid "Add a legend element"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:299
-msgid "Add an orientation element"
+msgid "Open a document"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
-msgid "Add a scale element"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:301
-msgid "Add a picture element"
+msgid "Export the document"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
-msgid "Add a circle element"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:303
-msgid "Add a polygon element"
+msgid "Add a map element"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
-msgid "Move to the back"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:305
-msgid "Move down"
+msgid "Add a text element"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
-msgid "Move on"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:307
-msgid "Move to the front"
+msgid "Add a legend element"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
-msgid "Align to the left"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:309
-msgid "Align to the center"
+msgid "Add an orientation element"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
-msgid "Align to the right"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:311
-msgid "Align to the bottom"
+msgid "Add a scale element"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
-msgid "Align to the middle"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:313
-msgid "Align to the top"
+msgid "Add a picture element"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
-msgid "Show selected elements properties"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:315
-msgid "Delete selected elements"
+msgid "Add a circle element"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
-msgid "Redraw selected elements"
-msgstr ""
-
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:317
-msgid "Undo the last action"
+msgid "Add a polygon element"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
-msgid "Redo the last action"
+msgid "Move to the back"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
-msgid "X"
+msgid "Move on"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:325
-msgid "Y"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
+msgid "Align to the center"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
+msgid "Align to the middle"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
 msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:331
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
 msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:256
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
+msgstr ""
+
 #: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
 msgid "First create a new document or open an existing one."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:310
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
 msgid ""
 "Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
 "ratio"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:129
-msgid "Can't undo..;"
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:145
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
 msgid "Can't redo."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:133
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:97
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
 msgid ""
 "Error on export : The list of GraphicalElement to export does not contain "
 "any Document GE."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:244
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
 msgid "vector"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:246
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
 msgid "raster"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:312
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
 msgid "PDF"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:317
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
 msgid "Export the document as a PDF file."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:429
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
 msgid "PDF file"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:170
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
 msgid "png"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:171
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
 msgid "jpg"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:172
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
 msgid "gif"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
 msgid "Image"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:184
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
 msgid "Export the document ad an image."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
 msgid " image file"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:78
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
 msgid "New document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:79
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
 msgid "Are you sure to create a new Document ?"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:80
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
 msgid "Unsaved changes will be lost."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:117
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
 msgid "Action not supported yet."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:132
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/ku.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/ku.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Kurdish (http://www.transifex.com/projects/p/orbisgis/language/ku/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: ku\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/ku_IQ.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/ku_IQ.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Kurdish (Iraq) (http://www.transifex.com/projects/p/orbisgis/language/ku_IQ/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: ku_IQ\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/pt.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/pt.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Portuguese (http://www.transifex.com/projects/p/orbisgis/language/pt/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/pt_BR.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/pt_BR.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/orbisgis/language/pt_BR/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/ru_RU.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/ru_RU.po
@@ -7,34 +7,77 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Russian (Russia) (http://www.transifex.com/projects/p/orbisgis/language/ru_RU/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru_RU\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/tr.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/tr.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Turkish (http://www.transifex.com/projects/p/orbisgis/language/tr/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: tr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""

--- a/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/zh.po
+++ b/MapComposer/src/main/resources/org/orbisgis/mapcomposer/translation/language/zh.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OrbisGIS\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-02-05 16:35+0100\n"
-"PO-Revision-Date: 2015-02-20 14:00+0000\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"POT-Creation-Date: 2015-05-26 13:26+0200\n"
+"PO-Revision-Date: 2015-05-26 11:28+0000\n"
+"Last-Translator: Sylvain Palominos <SPalominos@users.noreply.github.com>\n"
 "Language-Team: Chinese (http://www.transifex.com/projects/p/orbisgis/language/zh/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -17,24 +17,67 @@ msgstr ""
 "Language: zh\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:61
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:65
 msgid "Orientation"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:64
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:68
 msgid "Format"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:67
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:71
+msgid "Unit"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:74
 msgid "Name"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:70
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:77
 msgid "Document title"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:53
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:51
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:238
+msgid "A4"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:239
+msgid "A3"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:240
+msgid "Custom"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:312
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:202
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:419
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:472
+msgid "mm"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:313
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:124
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:208
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:413
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:474
+msgid "in"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:314
+msgid "pixel"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:387
+msgid "Portrait"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/Document.java:388
+msgid "Landscape"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/illustration/SimpleIllustrationGE.java:50
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Orientation.java:48
 msgid "Path"
 msgstr ""
 
@@ -56,6 +99,10 @@ msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:75
 msgid "Width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/SimpleGE.java:84
+msgid "z"
 msgstr ""
 
 #: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:71
@@ -90,188 +137,378 @@ msgstr ""
 msgid "Font size"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:98
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:99
 msgid "Some text"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:49
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:117
+msgid "PLAIN"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:118
+msgid "ITALIC"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:119
+msgid "BOLD"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:121
+msgid "LEFT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:122
+msgid "CENTER"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/text/TextElement.java:123
+msgid "RIGHT"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/Scale.java:46
 msgid "Link to MapImage"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:53
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/cartographic/SimpleCartoGE.java:50
 msgid "OWS-Context path"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:178
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:51
+msgid "Line"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:56
+msgid "Empty"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:61
+msgid "Shape color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:66
+msgid "Shape alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:71
+msgid "Border width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:76
+msgid "Border alpha"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:81
+msgid "Border color"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/graphicalelement/element/shape/SimpleShapeGE.java:86
+msgid "Border style"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:189
 #, java-format
 msgid ""
 "File version {0} isn't compatible with the MapComposer version. Should be "
-"{1}"
+"{1}."
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:200
-msgid "Load document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:212
+msgid "Load document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:230
-msgid "Save document project"
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:213
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:244
+msgid "XML save files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:118
+#: org/orbisgis/mapcomposer/model/utils/SaveAndLoadHandler.java:243
+msgid "Save document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:100
+msgid "width"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/graphicalelement/DocumentRenderer.java:116
+msgid "height"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/UIDialogExportConfiguration.java:111
+msgid "Export configuration"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/utils/CompositionJPanel.java:129
 msgid ""
 "<html>Holding <strong>Alt Gr</strong> : resize the representation of the "
-"element.<br/>Holding <strong>Shift</strong> : resire the element and keeps "
+"element.<br/>Holding <strong>Shift</strong> : resize the element and keeps "
 "the ratio width/height.</html>"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:122
+#: org/orbisgis/mapcomposer/view/utils/UIDialogProperties.java:175
 msgid "Configuration"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:54
-msgid "Ok"
+#: org/orbisgis/mapcomposer/view/utils/ColorChooser.java:66
+msgid "Color chooser"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:88
-#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:112
+#: org/orbisgis/mapcomposer/view/configurationattribute/ColorRenderer.java:60
+msgid "Text demo"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:89
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:114
 msgid "Select source"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:132
-msgid "Create a new document (Ctrl + N)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:91
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:116
+msgid "All files"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:133
-msgid "Show the document configuration dialog (Ctrl + D)"
+#: org/orbisgis/mapcomposer/view/configurationattribute/SourceRenderer.java:98
+msgid "Browse"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:134
-msgid "Save the document (Ctrl + S)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:409
+msgid "px"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:135
-msgid "Open a document (Ctrl + L)"
+#: org/orbisgis/mapcomposer/view/ui/CompositionArea.java:421
+msgid "x : "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:136
-msgid "Export the document (Ctrl + E)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:292
+msgid "Create a new document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:138
-msgid "Add a map element (Alt + M)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:294
+msgid "Show the document configuration dialog"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:139
-msgid "Add a text element (Alt + T)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:296
+msgid "Save the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:140
-msgid "Add a legend element (Alt + L)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:298
+msgid "Open a document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:141
-msgid "Add an orientation element (Alt + O)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:300
+msgid "Export the document"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:142
-msgid "Add a scale element (Alt + S)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:302
+msgid "Add a map element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:143
-msgid "Add a picture element (Alt + I)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:304
+msgid "Add a text element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:145
-msgid "Add a circle element (Alt + C)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:306
+msgid "Add a legend element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:146
-msgid "Add a polygon element (Alt + Y)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:308
+msgid "Add an orientation element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:148
-msgid "Move to the back (Alt + PageDown)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:310
+msgid "Add a scale element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:149
-msgid "Move down (Alt + Down)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:312
+msgid "Add a picture element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:150
-msgid "Move on (Alt + Up)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:314
+msgid "Add a circle element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:151
-msgid "Move to the front (Alt + PageUp)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:316
+msgid "Add a polygon element"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:153
-msgid "Align to the left (Alt + numpad 4)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:318
+msgid "Move to the back"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:154
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:320
+msgid "Move down"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:322
+msgid "Move on"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:324
+msgid "Move to the front"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:326
+msgid "Align to the left"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:328
 msgid "Align to the center"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:155
-msgid "Align to the right (Alt + numpad 6)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:330
+msgid "Align to the right"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:156
-msgid "Align to the bottom (Alt + numpad 2)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:332
+msgid "Align to the bottom"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:157
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:334
 msgid "Align to the middle"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:158
-msgid "Align to the top (Alt + numpad 8)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:336
+msgid "Align to the top"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:160
-msgid "Show selected elements properties (Ctrl + P)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:338
+msgid "Show selected elements properties"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:161
-msgid "Delete selected elements (DELETE)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:340
+msgid "Delete selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:162
-msgid "Redraw selected elements (Ctrl + R)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:342
+msgid "Redraw selected elements"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:163
-msgid "Undo the last action (Ctrl + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:344
+msgid "Undo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:164
-msgid "Redo the last action (Ctrl + Shift + Z)"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:346
+msgid "Redo the last action"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:252
-#: org/orbisgis/mapcomposer/controller/GEController.java:258
-msgid "First create a new document or open an existing project."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:351
+msgid "X"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/GEController.java:301
-msgid "Now you can draw the GraphicalElement."
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:354
+msgid "Y"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:121
-msgid "Can't undo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:357
+msgid "WIDTH"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/MainController.java:137
-msgid "Can't redo"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:360
+msgid "HEIGHT"
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/UIController.java:86
-#: org/orbisgis/mapcomposer/controller/UIController.java:109
-#: org/orbisgis/mapcomposer/controller/UIController.java:113
-msgid "Action not supported yet"
+#: org/orbisgis/mapcomposer/view/ui/MainWindow.java:565
+msgid "MapComposer document - "
 msgstr ""
 
-#: org/orbisgis/mapcomposer/controller/IOController.java:115
+#: org/orbisgis/mapcomposer/controller/GEController.java:263
+#: org/orbisgis/mapcomposer/controller/GEController.java:270
+msgid "First create a new document or open an existing one."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/GEController.java:315
+msgid ""
+"Now you can draw the GraphicalElement. Hold SHIFT to keep the width/height "
+"ratio"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:133
+msgid "Can't undo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/MainController.java:150
+msgid "Can't redo."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:137
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:102
+msgid ""
+"Error on export : The list of GraphicalElement to export does not contain "
+"any Document GE."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:258
+msgid "vector"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:260
+msgid "raster"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:326
+msgid "PDF"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:331
+msgid "Export the document as a PDF file."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportPDFThread.java:443
+msgid "PDF file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:179
+msgid "Image type : "
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:181
+msgid "png"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:182
+msgid "jpg"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:183
+msgid "gif"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:190
+msgid "Image"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:195
+msgid "Export the document ad an image."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/utils/exportThreads/ExportImageThread.java:201
+msgid " image file"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:79
+msgid "New document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:80
+msgid "Are you sure to create a new Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:81
+#: org/orbisgis/mapcomposer/controller/UIController.java:95
+msgid "Unsaved changes will be lost."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:93
+msgid "Open document"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:94
+msgid "Are you sure to open an existing Document ?"
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/UIController.java:115
+msgid "Action not supported yet."
+msgstr ""
+
+#: org/orbisgis/mapcomposer/controller/IOController.java:135
 msgid "Export document"
 msgstr ""


### PR DESCRIPTION
### Release the version 1.0.4

### Implements the Custom document format :
- The user can now specify custom values for the document width and height.
- Adapts the Document configuration UI to those changes. It now contains two spinners (for the document height and width) which is linked to the unit, format and orientation selection (i.e. when the unit is changed, the value of width and height are converted).

### Updates the translations :
- Ensure that the string used for building the save xml are not translated.
- Adds the missing String.
- Update the French translation.

### Fixes different exception get and behaviour :
- The configuration panel gets on the document creation is the same as the one editing it.
- Now MapComposer find the OwsContext in the workspace and also in the folders added in the OrbisGIS MapManager.
- Fixes the exports : the z index of the elements wasn't respected.
- Fixes exceptions get because of a missing OwsContext.

### Fixes the issues :
#15 : The user can still use the MapComposer while it's rendering a map
#20 : The text configuration panel has been customized
#21 : The MapComposer has been added in the OrbisGIS plugin manager and in the toolbar
#34 : the transparency goes from 0 to 100
#35 #36 : By holding the SHIFT key, the ratio between width and height of an image is kept
#37 : The CompositionArea scales are thinner